### PR TITLE
file_host: nest routes under /api/v1, keep /health unversioned

### DIFF
--- a/apps/servers/file_host/src/lib.rs
+++ b/apps/servers/file_host/src/lib.rs
@@ -20,6 +20,11 @@ pub mod routes;
 pub mod utils;
 pub mod websocket;
 
+/// Base path all versioned HTTP routers are nested under in `main.rs`.
+/// `/health` is the deliberate exception: it stays unversioned so load
+/// balancers and orchestrators don't need to track API version bumps.
+pub const API_V1_BASE_PATH: &str = "/api/v1";
+
 pub use crate::websocket::WebSocketFsm;
 pub use cache::{CacheConfig, CacheStore, DedupCache};
 pub use config::*;

--- a/apps/servers/file_host/src/main.rs
+++ b/apps/servers/file_host/src/main.rs
@@ -19,7 +19,7 @@ use clap::Parser;
 use file_host::rate_limiter::token_bucket::rate_limit_middleware;
 use file_host::{
 	error::{FileHostError, GSheetDeriveError},
-	perform_health_check, AppState, AudioServiceError, Config, DedupCache,
+	perform_health_check, AppState, AudioServiceError, Config, DedupCache, API_V1_BASE_PATH,
 };
 use sdk::ReadDrive;
 use some_services::rate_limiter::TokenBucketRateLimiter;
@@ -68,7 +68,7 @@ async fn main() -> Result<()> {
 
 	let app_state = AppState::build(config.clone(), pool, shutdown_token.clone()).await?;
 
-	let mut protected_routes = Router::new()
+	let mut versioned_routes = Router::new()
 		.merge(get_sheets(&config))
 		.merge(get_gdrive_image())
 		.merge(get_repos())
@@ -76,15 +76,15 @@ async fn main() -> Result<()> {
 		.merge(tabs())
 		.merge(get_audio(&config))
 		.merge(post_now_playing())
-		.merge(get_health())
 		.merge(post_utterance());
 
 	let max_requests = config.clone().max_request_size.try_into()?;
 	// TODO: Is this even working! boyo needs to know!
-	protected_routes = protected_routes.layer(from_fn_with_state(Arc::new(TokenBucketRateLimiter::new(max_requests)), rate_limit_middleware));
+	versioned_routes = versioned_routes.layer(from_fn_with_state(Arc::new(TokenBucketRateLimiter::new(max_requests)), rate_limit_middleware));
 
 	let app = Router::new()
-		.merge(protected_routes)
+		.nest(API_V1_BASE_PATH, versioned_routes)
+		.merge(get_health())
 		.merge(app_state.realtime.ws.clone().router())
 		.with_state(app_state.clone());
 


### PR DESCRIPTION
## Description

Closes #103.

Nests all HTTP routers in `apps/servers/file_host` under a shared, versioned `/api/v1` base path (`main.rs`), and introduces `file_host::API_V1_BASE_PATH` as the single source of truth for it. This lets the client centralize a `baseUrl` + version prefix instead of hardcoding full URLs per call, as described in the issue.

`/health` is deliberately left unversioned and out of the rate-limited router — health checks are typically consumed by load balancers/orchestrators that shouldn't need to track API version bumps.

Companion client-side change: paulgsc/some-ui#578 adds an `apiUrl()` helper to `@some-ui/fetch-kit` and moves its call sites onto the new `/api/v1` prefix.

### Route path changes

All routes previously merged at root now live under `/api/v1`, e.g.:
- `/get_attributions/:sheet_id` → `/api/v1/get_attributions/:sheet_id`
- `/gdrive/image/:image_id` → `/api/v1/gdrive/image/:image_id`
- `/tabs`, `/mood_events`, `/get_audio/:id`, `/now-playing`, `/utter`, `/get_github_repos` → same, under `/api/v1`
- `/health` is unchanged.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- `cargo check -p file_host` compiles cleanly against a local SQLite DB with all migrations applied.
- Manual review of the router composition before/after nesting to confirm every existing route is preserved under the new prefix and `/health` is the only unversioned exception.

- [x] Compiles cleanly (`cargo check -p file_host`)
- [ ] Integration test hitting the running server

## Additional Notes

This is a breaking wire-contract change for every existing caller of `file_host` (routes move under `/api/v1`). It's coordinated with paulgsc/some-ui#578, which should land alongside this one.
