### PR TITLE
fix(clippy): clear lints in obs-websocket types, some-transport, ws-conn-manager

### DIFF
--- a/crates/obs-websocket/src/messages/parsers/event.rs
+++ b/crates/obs-websocket/src/messages/parsers/event.rs
@@ -16,7 +16,7 @@ impl EventMessageParser {
 		let val = Value::Object(d.clone());
 		let d_extractor = JsonExtractor::new(&val, "Event data");
 		let event_type_str = d_extractor.get_string("eventType")?;
-		let event_type = ObsEventType::from_str(event_type_str);
+		let event_type = ObsEventType::from(event_type_str);
 
 		trace!("Parsing event type: {}", event_type_str);
 

--- a/crates/obs-websocket/src/messages/parsers/response.rs
+++ b/crates/obs-websocket/src/messages/parsers/response.rs
@@ -16,7 +16,7 @@ impl ResponseMessageParser {
 		let val = Value::Object(d.clone());
 		let d_extractor = JsonExtractor::new(&val, "Response data");
 		let request_type_str = d_extractor.get_string("requestType")?;
-		let request_type = ObsRequestType::from_str(request_type_str);
+		let request_type = ObsRequestType::from(request_type_str);
 
 		trace!("Parsing response type: {}", request_type_str);
 

--- a/crates/obs-websocket/src/types.rs
+++ b/crates/obs-websocket/src/types.rs
@@ -103,6 +103,7 @@ pub enum ObsRequestType {
 }
 
 impl ObsRequestType {
+	#[must_use]
 	pub fn as_str(&self) -> &str {
 		match self {
 			Self::GetVersion => "GetVersion",
@@ -149,8 +150,12 @@ impl ObsRequestType {
 			Self::Unknown(s) => s,
 		}
 	}
+}
 
-	pub fn from_str(s: &str) -> Self {
+impl From<&str> for ObsRequestType {
+	/// Maps an OBS request type name to its variant, falling back to
+	/// [`Self::Unknown`] for names this crate does not model.
+	fn from(s: &str) -> Self {
 		match s {
 			"GetStreamStatus" => Self::GetStreamStatus,
 			"GetRecordStatus" => Self::GetRecordStatus,
@@ -231,6 +236,7 @@ pub enum ObsEventType {
 
 impl ObsEventType {
 	#[allow(dead_code)]
+	#[must_use]
 	pub fn as_str(&self) -> &str {
 		match self {
 			Self::StreamStateChanged => "StreamStateChanged",
@@ -248,8 +254,12 @@ impl ObsEventType {
 			Self::Unknown(s) => s,
 		}
 	}
+}
 
-	pub fn from_str(s: &str) -> Self {
+impl From<&str> for ObsEventType {
+	/// Maps an OBS event type name to its variant, falling back to
+	/// [`Self::Unknown`] for names this crate does not model.
+	fn from(s: &str) -> Self {
 		match s {
 			"StreamStateChanged" => Self::StreamStateChanged,
 			"RecordStateChanged" => Self::RecordStateChanged,
@@ -716,7 +726,8 @@ pub enum YouTubePrivacy {
 }
 
 impl YouTubePrivacy {
-	pub fn as_str(&self) -> &str {
+	#[must_use]
+	pub const fn as_str(&self) -> &str {
 		match self {
 			Self::Public => "public",
 			Self::Unlisted => "unlisted",
@@ -815,7 +826,8 @@ impl Default for ObsStats {
 
 impl ObsEvent {
 	/// Check if this event should trigger a status broadcast
-	pub fn should_broadcast(&self) -> bool {
+	#[must_use]
+	pub const fn should_broadcast(&self) -> bool {
 		matches!(
 			self,
 			Self::StreamStatusResponse(_)

--- a/crates/some-transport/src/receiver.rs
+++ b/crates/some-transport/src/receiver.rs
@@ -50,12 +50,32 @@ where
 	}
 
 	/// Receives a message asynchronously, waiting until one is available.
+	///
+	/// # Errors
+	///
+	/// Propagates whatever the underlying receiver reports — typically
+	/// [`TransportError::Closed`] once the channel has been closed, or
+	/// [`TransportError::Overflowed`] if this receiver lagged far enough
+	/// behind that messages were dropped.
+	///
+	/// [`TransportError::Closed`]: crate::error::TransportError::Closed
+	/// [`TransportError::Overflowed`]: crate::error::TransportError::Overflowed
 	#[inline]
 	pub async fn recv(&mut self) -> Result<E> {
 		self.inner.recv().await
 	}
 
 	/// Attempts to receive a message without blocking.
+	///
+	/// # Errors
+	///
+	/// Propagates whatever the underlying receiver reports — typically
+	/// [`TransportError::Closed`] when the channel is closed, or
+	/// [`TransportError::Overflowed`] when messages were dropped. An empty
+	/// channel is also reported as an error rather than blocking.
+	///
+	/// [`TransportError::Closed`]: crate::error::TransportError::Closed
+	/// [`TransportError::Overflowed`]: crate::error::TransportError::Overflowed
 	#[inline]
 	pub fn try_recv(&mut self) -> Result<E> {
 		self.inner.try_recv()
@@ -75,7 +95,7 @@ where
 
 	/// Returns a mutable reference to the inner receiver.
 	#[inline]
-	pub fn inner_mut(&mut self) -> &mut R {
+	pub const fn inner_mut(&mut self) -> &mut R {
 		&mut self.inner
 	}
 }
@@ -130,5 +150,15 @@ where
 	///
 	/// Returns immediately with either a message or an error indicating
 	/// the channel is empty, closed, or overflowed.
+	///
+	/// # Errors
+	///
+	/// Implementors should report [`TransportError::Closed`] once the
+	/// channel is closed and [`TransportError::Overflowed`] when messages
+	/// were dropped. An empty channel must also be reported as an error
+	/// rather than blocking.
+	///
+	/// [`TransportError::Closed`]: crate::error::TransportError::Closed
+	/// [`TransportError::Overflowed`]: crate::error::TransportError::Overflowed
 	fn try_recv(&mut self) -> Result<E>;
 }

--- a/crates/ws-conn-manager/src/lib.rs
+++ b/crates/ws-conn-manager/src/lib.rs
@@ -1,4 +1,4 @@
-//! # ConnectionGuard Crate
+//! # `ConnectionGuard` Crate
 //!
 //! This crate implements a *multi-tenant connection limiter* designed for
 //! environments such as WebSocket servers where each client may open
@@ -119,10 +119,10 @@
 //!   global from per-client resource pools.
 //! - Expose structured diagnostics for testing invariants under load.
 //! - Replace `tokio::spawn` in Drop with explicit async cleanup method.
-//! - Benchmark and optimize lock-free alternatives to VecDeque + DashMap.
+//! - Benchmark and optimize lock-free alternatives to `VecDeque` + `DashMap`.
 //!
 //! ---
-//! **Summary:**  
+//! **Summary:**\
 //! This crate currently provides *correct RAII-based invariant enforcement*
 //! for bounded connection concurrency with automatic cleanup, but fairness,
 //! fine-grained scheduling, and lock-free optimizations are deferred to
@@ -203,13 +203,14 @@ pub struct ConnectionGuardInner {
 	pub clients: DashMap<String, ClientState>,
 }
 
-/// Public ConnectionGuard
+/// Public `ConnectionGuard`
 #[derive(Clone)]
 pub struct ConnectionGuard {
 	pub inner: Arc<ConnectionGuardInner>,
 }
 
 impl ConnectionGuard {
+	#[must_use]
 	pub fn new() -> Self {
 		Self {
 			inner: Arc::new(ConnectionGuardInner {
@@ -219,6 +220,14 @@ impl ConnectionGuard {
 		}
 	}
 
+	/// Acquires a connection permit for `client_id`, queueing the caller if the
+	/// client is already at its per-client limit.
+	///
+	/// # Errors
+	///
+	/// Returns [`AcquireErrorKind::GlobalLimit`] if the global semaphore has
+	/// been closed, and [`AcquireErrorKind::QueueFull`] if the client is at its
+	/// per-client limit and its wait queue is already full.
 	pub async fn acquire(&self, client_id: String) -> Result<ConnectionPermit, AcquireError> {
 		info!("Client {} attempting to acquire connection permit", client_id);
 
@@ -257,8 +266,14 @@ impl ConnectionGuard {
 
 			let _ = rx.await;
 
-			// Re-acquire lock to increment active count
-			let client_state = self.inner.clients.get(&client_id).expect("client state should exist");
+			// Re-acquire lock to increment active count. `ConnectionPermit::cleanup`
+			// may have reclaimed the entry between signalling this waiter and the
+			// lookup below (it pops the waiter before deciding the state is idle),
+			// so recreate it instead of assuming it is still present.
+			let client_state = self.inner.clients.entry(client_id.clone()).or_insert_with(|| ClientState {
+				active: AtomicUsize::new(0),
+				queue: VecDeque::new(),
+			});
 			client_state.active.fetch_add(1, Ordering::SeqCst);
 
 			info!(
@@ -281,16 +296,19 @@ impl ConnectionGuard {
 		})
 	}
 
+	#[must_use]
 	pub fn try_acquire_permit_hint(&self) -> bool {
 		self.inner.global.available_permits() > 0
 	}
 
+	#[must_use]
 	pub fn active_global(&self) -> usize {
 		MAX_GLOBAL - self.inner.global.available_permits()
 	}
 
+	#[must_use]
 	pub fn active_per_client(&self, client_id: &str) -> usize {
-		self.inner.clients.get(client_id).map(|c| c.active.load(Ordering::SeqCst)).unwrap_or(0)
+		self.inner.clients.get(client_id).map_or(0, |c| c.active.load(Ordering::SeqCst))
 	}
 }
 


### PR DESCRIPTION
## Description

First batch of the pre-existing clippy backlog. The workspace denies `all` + `pedantic` + `nursery` + `cargo`, and there are a few hundred outstanding lints, so this PR is deliberately scoped to three areas to keep the diff reviewable. The rest of the workspace is untouched.

**`obs-websocket/src/types.rs` — 10 lints (the shared blocker)**

These particular lints were reported against *every* crate that depends on `obs-websocket`, because path dependencies are linted too. Clearing them removes the same 10 errors from `capture_repo`, `ws-events`, `file_host` and `cursorium`.

- Replaced the inherent `ObsRequestType::from_str` / `ObsEventType::from_str` with `From<&str>` impls. Both map unrecognized names to `Unknown` and cannot fail, so `From` is the honest trait — `FromStr` would have forced an `Infallible` error type that every caller has to unwrap. The inherent methods also shadowed `FromStr::from_str` (`should_implement_trait`). Both call sites in the event/response parsers updated.
- Added `#[must_use]` to the `as_str` accessors and `should_broadcast`; made `YouTubePrivacy::as_str` and `ObsEvent::should_broadcast` `const`.

**`some-transport` — now clean**

- Documented error conditions on `recv` / `try_recv` and the `try_recv` trait method; made `inner_mut` `const`.

**`ws-conn-manager` — now clean**

- **Fixed a latent panic in `acquire`.** After a queued waiter was signalled, the code looked the client entry up with `.expect("client state should exist")`. But `ConnectionPermit::cleanup` pops the waiter *before* it evaluates `active == 0 && queue.is_empty()` and removes the entry — so the woken task could find the entry already gone and panic. It now recreates the entry via the entry API, mirroring the acquire path. This was surfaced by `clippy::expect_used`.
- Replaced `map(..).unwrap_or(0)` with `map_or`, added `#[must_use]` to the accessors, documented `acquire`'s errors, and fixed doc-markdown nits.

**Deliberately left alone**

- `multiple_crate_versions` — a dependency-tree issue (duplicate `thiserror`, `tungstenite`, `windows_i686_gnullvm`, etc.), not something a code-cleanup PR should touch.
- The `ws-conn-manager` benches. Fixing the lib unmasked ~15 lints in `benches/connection_guard.rs` that were previously unreachable, but CI runs `cargo clippy --workspace -- -D warnings --no-deps` *without* `--all-targets`, so bench and test targets aren't linted. Out of scope for this batch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

The `from_str` → `From<&str>` change is technically a public API change on `obs-websocket`, but both types are internal to this workspace and both call sites are updated in this PR.

## How Has This Been Tested?

- [x] `cargo clippy -p <crate> --no-deps` (CI's flags) is clean for `some-transport` and `ws-conn-manager`; `obs-websocket/src/types.rs` reports zero lints.
- [x] `cargo fmt --check` clean on all three crates.
- [x] `cargo test -p some-transport -p ws-conn-manager` — neither crate has unit or integration tests. The two failing doctests in `some-transport` (unresolved `bincode` import in `# Example` blocks) fail identically on `main`; verified by stashing.
- [x] Confirmed no new breakage: `cargo check -p cursorium` reports the same 37 pre-existing compile errors before and after these changes.

**Test Configuration**:
* Toolchain: cargo 1.94.1 / clippy for rust 1.94.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — no test harness exists in these crates today; adding one for the `acquire` race would mean standing up scaffolding beyond this batch's scope
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Pre-existing CI failures elsewhere in the workspace (sqlx `DATABASE_URL` query-cache errors in `capture_repo` / `mood_event`, `E0282` type-annotation errors, and `cursorium`'s 37 compile errors) are unrelated to this change and were explicitly out of scope.

Remaining clippy backlog for future batches, roughly by size: `some-obs` (~137), `some-cache` (~74), `ws-connection` (~36), `file_reader` (~22), `orchestrator`, `gsheet_derive`, `enum-name-derive`, `sdk`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEjDbp9z6BDFDiXb7tGqXZ)_