### PR TITLE
fix(cursorium,ws-connection): declare ws-events feature and clear ws-connection lints

### DIFF
--- a/apps/servers/file_host/src/error.rs
+++ b/apps/servers/file_host/src/error.rs
@@ -242,7 +242,13 @@ impl IntoResponse for FileHostError {
 			_ => None,
 		};
 
-		let mut response = (status, Json(ErrorEnvelope { error: ErrorBody { code, message, details } })).into_response();
+		let mut response = (
+			status,
+			Json(ErrorEnvelope {
+				error: ErrorBody { code, message, details },
+			}),
+		)
+			.into_response();
 
 		if is_unauthorized {
 			response.headers_mut().insert(WWW_AUTHENTICATE, HeaderValue::from_static("Token"));

--- a/apps/servers/file_host/src/routes/audio_files.rs
+++ b/apps/servers/file_host/src/routes/audio_files.rs
@@ -16,7 +16,11 @@ where
 	S: Clone + Send + Sync + 'static,
 	AppState: FromRef<S>,
 {
-	let cors = allowlisted_cors(config, vec![Method::GET, Method::POST], vec![CONTENT_TYPE, AUTHORIZATION, CACHE_CONTROL, ETAG, LAST_MODIFIED]);
+	let cors = allowlisted_cors(
+		config,
+		vec![Method::GET, Method::POST],
+		vec![CONTENT_TYPE, AUTHORIZATION, CACHE_CONTROL, ETAG, LAST_MODIFIED],
+	);
 
 	Router::new()
 		// Get specific audio file by ID

--- a/crates/cursorium/Cargo.toml
+++ b/crates/cursorium/Cargo.toml
@@ -16,7 +16,7 @@ serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 smallvec = "1.15.1"
 
-ws-events = { workspace = true }
+ws-events = { workspace = true, features = ["ws-events"] }
 
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time", "macros", "rt-multi-thread"] }

--- a/crates/ws-connection/src/actor/handle.rs
+++ b/crates/ws-connection/src/actor/handle.rs
@@ -38,6 +38,11 @@ impl<K: EventKey> ConnectionHandle<K> {
 	}
 
 	/// Record recent activity
+	///
+	/// # Errors
+	///
+	/// Returns [`ConnectionError::ActorUnavailable`] if the actor has already
+	/// shut down and its command channel is closed.
 	pub async fn record_activity(&self) -> Result<()> {
 		self
 			.sender
@@ -47,6 +52,11 @@ impl<K: EventKey> ConnectionHandle<K> {
 	}
 
 	/// Subscribe to event types
+	///
+	/// # Errors
+	///
+	/// Returns [`ConnectionError::ActorUnavailable`] if the actor has already
+	/// shut down and its command channel is closed.
 	pub async fn subscribe(&self, event_types: Vec<K>) -> Result<()> {
 		self
 			.sender
@@ -56,6 +66,11 @@ impl<K: EventKey> ConnectionHandle<K> {
 	}
 
 	/// Unsubscribe from event types
+	///
+	/// # Errors
+	///
+	/// Returns [`ConnectionError::ActorUnavailable`] if the actor has already
+	/// shut down and its command channel is closed.
 	pub async fn unsubscribe(&self, event_types: Vec<K>) -> Result<()> {
 		self
 			.sender
@@ -65,6 +80,12 @@ impl<K: EventKey> ConnectionHandle<K> {
 	}
 
 	/// Check if subscribed to an event type
+	///
+	/// # Errors
+	///
+	/// Returns [`ConnectionError::ActorUnavailable`] if the actor has already
+	/// shut down and its command channel is closed, or if the actor drops the
+	/// reply channel before answering.
 	pub async fn is_subscribed_to(&self, event_type: K) -> Result<bool> {
 		let (tx, rx) = oneshot::channel();
 		self
@@ -77,6 +98,12 @@ impl<K: EventKey> ConnectionHandle<K> {
 	}
 
 	/// Get all subscriptions
+	///
+	/// # Errors
+	///
+	/// Returns [`ConnectionError::ActorUnavailable`] if the actor has already
+	/// shut down and its command channel is closed, or if the actor drops the
+	/// reply channel before answering.
 	pub async fn get_subscriptions(&self) -> Result<HashSet<K>> {
 		let (tx, rx) = oneshot::channel();
 		self
@@ -89,6 +116,11 @@ impl<K: EventKey> ConnectionHandle<K> {
 	}
 
 	/// Check if connection should be marked stale
+	///
+	/// # Errors
+	///
+	/// Returns [`ConnectionError::ActorUnavailable`] if the actor has already
+	/// shut down and its command channel is closed.
 	pub async fn check_stale(&self, timeout: Duration) -> Result<()> {
 		self
 			.sender
@@ -98,6 +130,11 @@ impl<K: EventKey> ConnectionHandle<K> {
 	}
 
 	/// Mark connection as stale
+	///
+	/// # Errors
+	///
+	/// Returns [`ConnectionError::ActorUnavailable`] if the actor has already
+	/// shut down and its command channel is closed.
 	pub async fn mark_stale(&self, reason: String) -> Result<()> {
 		self
 			.sender
@@ -107,6 +144,11 @@ impl<K: EventKey> ConnectionHandle<K> {
 	}
 
 	/// Disconnect the connection
+	///
+	/// # Errors
+	///
+	/// Returns [`ConnectionError::ActorUnavailable`] if the actor has already
+	/// shut down and its command channel is closed.
 	pub async fn disconnect(&self, reason: String) -> Result<()> {
 		self
 			.sender
@@ -116,6 +158,12 @@ impl<K: EventKey> ConnectionHandle<K> {
 	}
 
 	/// Get current connection state
+	///
+	/// # Errors
+	///
+	/// Returns [`ConnectionError::ActorUnavailable`] if the actor has already
+	/// shut down and its command channel is closed, or if the actor drops the
+	/// reply channel before answering.
 	pub async fn get_state(&self) -> Result<ConnectionState> {
 		let (tx, rx) = oneshot::channel();
 		self
@@ -128,6 +176,13 @@ impl<K: EventKey> ConnectionHandle<K> {
 	}
 
 	/// Request actor shutdown
+	///
+	/// # Errors
+	///
+	/// Currently infallible: a closed command channel means the actor is
+	/// already gone, which satisfies the request, so the cancellation token is
+	/// still tripped and `Ok(())` returned. The signature stays fallible so
+	/// shutdown can start reporting failures without a breaking change.
 	pub async fn shutdown(&self) -> Result<()> {
 		let _ = self
 			.sender

--- a/crates/ws-connection/src/actor/state.rs
+++ b/crates/ws-connection/src/actor/state.rs
@@ -53,6 +53,7 @@ impl ConnectionState {
 	}
 
 	/// Returns a concise string representation of the state
+	#[must_use]
 	pub fn as_str(&self) -> String {
 		let mut s = if self.is_active { "active".to_string() } else { "inactive".to_string() };
 

--- a/crates/ws-connection/src/core/conn.rs
+++ b/crates/ws-connection/src/core/conn.rs
@@ -15,6 +15,7 @@ pub struct Connection {
 
 impl Connection {
 	/// Create a new connection
+	#[must_use]
 	pub fn new(client_id: ClientId, source_addr: SocketAddr) -> Self {
 		Self {
 			id: ConnectionId::new(),
@@ -25,6 +26,7 @@ impl Connection {
 	}
 
 	/// Get connection duration
+	#[must_use]
 	pub fn get_duration(&self) -> Duration {
 		self.established_at.elapsed()
 	}

--- a/crates/ws-connection/src/core/store.rs
+++ b/crates/ws-connection/src/core/store.rs
@@ -11,6 +11,7 @@ pub struct ConnectionStore<K: EventKey = String> {
 }
 
 impl<K: EventKey> ConnectionStore<K> {
+	#[must_use]
 	pub fn new() -> Self {
 		Self {
 			handles: Arc::new(DashMap::new()),
@@ -18,6 +19,7 @@ impl<K: EventKey> ConnectionStore<K> {
 	}
 
 	/// Insert connection handle and spawn its actor
+	#[must_use]
 	pub fn insert(self: &Arc<Self>, key: String, connection: Connection, parent_token: &CancellationToken) -> ConnectionHandle<K> {
 		let (handle, actor, token) = ConnectionHandle::new(connection, 100, parent_token);
 		let store = self.clone();
@@ -26,10 +28,10 @@ impl<K: EventKey> ConnectionStore<K> {
 			let key = key.clone();
 			async move {
 				tokio::select! {
-					_ = actor.run() => {
+					() = actor.run() => {
 						tracing::info!("actor {key} finished normally");
 					}
-					_ = token.cancelled() => {
+					() = token.cancelled() => {
 						tracing::info!("actor {key} received cancellation");
 						store.remove(&key).await; // graceful cleanup if implemented
 					}
@@ -42,6 +44,7 @@ impl<K: EventKey> ConnectionStore<K> {
 	}
 
 	/// Get connection handle
+	#[must_use]
 	pub fn get(&self, key: &str) -> Option<ConnectionHandle<K>> {
 		self.handles.get(key).map(|entry| entry.value().clone())
 	}
@@ -56,14 +59,17 @@ impl<K: EventKey> ConnectionStore<K> {
 		}
 	}
 
+	#[must_use]
 	pub fn len(&self) -> usize {
 		self.handles.len()
 	}
 
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		self.handles.is_empty()
 	}
 
+	#[must_use]
 	pub fn keys(&self) -> Vec<String> {
 		self.handles.iter().map(|entry| entry.key().clone()).collect()
 	}
@@ -123,10 +129,10 @@ impl<K: EventKey> ConnectionStore<K> {
 
 		while let Some(result) = join_set.join_next().await {
 			match result {
-				Ok(Ok(state)) => {
-					if state.is_active {
+				Ok(Ok(conn_state)) => {
+					if conn_state.is_active {
 						active += 1;
-					} else if state.is_stale {
+					} else if conn_state.is_stale {
 						stale += 1;
 					} else {
 						disconnected += 1;

--- a/crates/ws-connection/src/core/subscription.rs
+++ b/crates/ws-connection/src/core/subscription.rs
@@ -87,7 +87,7 @@ impl<K: EventKey> SubscriptionManager<K> {
 
 	/// Get all current subscriptions.
 	#[must_use]
-	pub fn get_subscriptions(&self) -> &HashSet<K> {
+	pub const fn get_subscriptions(&self) -> &HashSet<K> {
 		&self.subscriptions
 	}
 
@@ -157,12 +157,14 @@ impl SubscriptionChange {
 	pub fn net_change(&self) -> i32 {
 		let added = i64::try_from(self.added).unwrap_or(i64::MAX);
 		let removed = i64::try_from(self.removed).unwrap_or(i64::MAX);
-		(added - removed).clamp(i32::MIN as i64, i32::MAX as i64) as i32
+		let net = added - removed;
+		// Saturate rather than truncate if the delta exceeds `i32`.
+		i32::try_from(net).unwrap_or_else(|_| if net.is_negative() { i32::MIN } else { i32::MAX })
 	}
 
 	/// Whether there were any changes.
 	#[must_use]
-	pub fn has_changes(&self) -> bool {
+	pub const fn has_changes(&self) -> bool {
 		self.added > 0 || self.removed > 0
 	}
 }

--- a/crates/ws-connection/src/types.rs
+++ b/crates/ws-connection/src/types.rs
@@ -6,24 +6,35 @@ use uuid::Uuid;
 pub struct ConnectionId(Uuid);
 
 impl ConnectionId {
+	#[must_use]
 	pub fn new() -> Self {
 		Self(Uuid::new_v4()) // or new_v7() if you want time-ordered
 	}
 
-	pub fn from_uuid(uuid: Uuid) -> Self {
+	#[must_use]
+	pub const fn from_uuid(uuid: Uuid) -> Self {
 		Self(uuid)
 	}
 
-	pub fn as_uuid(&self) -> &Uuid {
+	#[must_use]
+	pub const fn as_uuid(&self) -> &Uuid {
 		&self.0
 	}
 
+	#[must_use]
 	pub fn as_string(&self) -> String {
 		self.0.to_string()
 	}
 
-	pub fn as_bytes(&self) -> &[u8; 16] {
+	#[must_use]
+	pub const fn as_bytes(&self) -> &[u8; 16] {
 		self.0.as_bytes()
+	}
+}
+
+impl Default for ConnectionId {
+	fn default() -> Self {
+		Self::new()
 	}
 }
 
@@ -42,6 +53,7 @@ impl ClientId {
 		Self(id.into())
 	}
 
+	#[must_use]
 	pub fn as_str(&self) -> &str {
 		&self.0
 	}


### PR DESCRIPTION
## Description

### On the compiler errors: you were right, there weren't any

I need to correct what I said on #207. I reported "pre-existing compile errors" in `capture_repo` and `cursorium`. Re-checking properly:

- **`capture_repo`** — not a code error at all. sqlx's `query!` macros need either a live `DATABASE_URL` at compile time or a committed offline query cache, and CI provides exactly that (creates a sqlite DB, runs the merged migrations, then `cargo sqlx prepare --workspace`) before `cargo check`. My environment had neither. Once I built the DB from the two migrations and set `DATABASE_URL`, `cargo check --workspace` passes with zero errors. Nothing to fix.
- **`cursorium`** — a real bug, but not the one I described. It wasn't 37 legitimate compile errors; it was one missing feature declaration cascading.

So this PR contains **no compiler-error fixes**, because the workspace has none. What it does contain is the cursorium packaging bug and the `ws-connection` clippy batch.

### cursorium: missing feature declaration

`cursorium/src` imports `ws_events::events`, which is gated behind `#[cfg(feature = "ws-events")]`. But its manifest declared:

```toml
ws-events = { workspace = true }     # no features
```

It compiled anyway — `orchestrator`, `some-obs` and `file_host` all enable `features = ["ws-events"]`, and cargo unifies features across a workspace build. So the crate built as part of the workspace but `cargo check -p cursorium` failed standalone with `E0432: unresolved import`. Now declares the feature it actually uses.

**This is CI-neutral.** A workspace build already resolved the feature, so cursorium's own 80 clippy lints were already being reported in CI — verified by building it on `main` alongside a crate that enables the feature and getting the identical count of 80. This change adds no new CI failures; it just makes the crate reproducible in isolation.

### ws-connection: 37 lints, now clean

- `# Errors` docs on the ten fallible `ConnectionHandle` methods, distinguishing send-only failures from those that can also lose the reply channel. `shutdown` is documented as presently infallible.
- `#[must_use]` across `types`, `store`, `conn`, `state`; added the `Default` impl for `ConnectionId` that clippy wants alongside a no-arg `new`.
- `const fn` for `from_uuid`, `as_uuid`, `as_bytes`, `get_subscriptions`, `has_changes`.
- `()` instead of `_` for unit patterns in the `tokio::select!`.
- `SubscriptionChange::net_change` rewritten. Was `(added - removed).clamp(i32::MIN as i64, i32::MAX as i64) as i32` — three cast lints. Now saturates via `i32::try_from(net).unwrap_or_else(..)`, which drops the casts and states the saturation intent directly instead of leaving it implicit in a clamp-then-truncate.
- Renamed the `state` binding in `stats` to `conn_state`; it was one character away from the `stale` counter in the same scope (`similar_names`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

`#[must_use]` on `ConnectionStore::insert` is the one addition that could bite callers who discard the handle. Verified none do — `cargo check --workspace` produces no `unused_must_use` warnings.

## How Has This Been Tested?

- [x] `cargo check --workspace` (CI's exact command) — **zero errors**, with `DATABASE_URL` pointed at a sqlite DB built from both crates' migrations, mirroring CI's sqlx prepare step.
- [x] `cargo clippy -p ws-connection --no-deps` — zero source lints. Same for `some-transport` and `ws-conn-manager` from the previous batch.
- [x] `cargo check -p cursorium` now succeeds standalone (previously E0432).
- [x] `cargo fmt --all` run; `cargo fmt --all --check` clean.
- [x] No regressions: `cargo check -p ws-connection --all-targets` produces byte-for-byte identical output before and after these changes.

**Test Configuration**:
* Toolchain: cargo 1.94.1 / clippy for rust 1.94.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests — no new behavior to test; `net_change`'s saturation is the only semantic change and it preserves the previous clamp result for all in-range inputs
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

`cargo fmt --all` also reformatted two `file_host` files I didn't otherwise touch (`error.rs`, `routes/audio_files.rs`). That drift is pre-existing — `main` is not fmt-clean — and since you asked me to run fmt I kept the fix rather than selectively reverting. Two small hunks, both struct-literal/fn-call width.

Still failing on `--all-targets` and untouched here: `crates/ws-connection/tests/` (both test files are written against a much older `Connection` API — ~160 errors) and one `file_host` bin target. CI does not pass `--all-targets`, so none of this is in its path.

Remaining clippy backlog: `some-obs` (~137), `some-cache` (~74), `cursorium` (80, now visible standalone), `file_reader` (~22), `orchestrator`, `gsheet_derive`, `enum-name-derive`, `sdk`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEjDbp9z6BDFDiXb7tGqXZ)_