### PR TITLE
Add machine-readable HTTP route inventory for contract testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,3 +89,24 @@ build-multi: ## Build multi-platform image (linux/amd64,linux/arm64)
 check: ## Check if image exists locally
 	@docker images | grep $(DOCKER_REPO) || echo "No local images found for $(DOCKER_REPO)"
 
+
+# ── Contract boundary ────────────────────────────────────────────────────────
+# The client repo (paulgsc/some-ui) keeps a checked-in snapshot of this
+# server's HTTP surface and diffs its contracts against it. Regenerate the
+# snapshot whenever a route is added, renamed, or removed.
+#
+# `dump-routes` reads a compile-time constant, so it needs no config, no
+# database and no network — but building it does require DATABASE_URL to point
+# at a migrated SQLite file, because sqlx checks queries at compile time.
+
+ROUTES_JSON ?= routes.server.json
+
+.PHONY: routes routes-check
+
+routes: ## Emit the HTTP route inventory as JSON (override path with ROUTES_JSON=...)
+	@cargo run -q --bin dump-routes > $(ROUTES_JSON)
+	@echo "Wrote $(ROUTES_JSON) ($$(grep -c '"method"' $(ROUTES_JSON)) routes)"
+	@echo "Copy it to the client repo at packages/contract-harness/routes.server.json"
+
+routes-check: ## Assert the declared inventory still matches the actual routers
+	@cargo test -p file_host --lib routes::inventory

--- a/apps/servers/file_host/Cargo.toml
+++ b/apps/servers/file_host/Cargo.toml
@@ -11,6 +11,17 @@ homepage.workspace = true
 license.workspace = true
 edition.workspace = true
 
+# Declared explicitly because the second binary needs a name Cargo would not
+# derive from its filename. `dump-routes` emits the HTTP surface as JSON for
+# the client repo's contract harness; see `src/routes/inventory.rs`.
+[[bin]]
+name = "file_host"
+path = "src/main.rs"
+
+[[bin]]
+name = "dump-routes"
+path = "src/bin/dump_routes.rs"
+
 [dependencies]
 # path crates
 sdk  = { workspace = true }
@@ -62,6 +73,11 @@ tracing-opentelemetry = { workspace = true }
 some-cache.workspace = true
 capture_repo = { workspace = true }
 
+
+[dev-dependencies]
+# `test-util` gives the paused clock the sliding-window rate limiter tests use
+# to step over a sixty-second window without sleeping for it.
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 
 [lints]
 workspace = true

--- a/apps/servers/file_host/docs/route-inventory.md
+++ b/apps/servers/file_host/docs/route-inventory.md
@@ -1,0 +1,75 @@
+# Route inventory
+
+`file_host` publishes a machine-readable description of its own HTTP surface.
+The client repo (`paulgsc/some-ui`) consumes it to check that the requests it
+makes still target routes that exist.
+
+## Why
+
+`axum::Router` is write-only. Once routes are registered there is no way to ask
+it what it accepts, so the boundary this server exposes is invisible to
+everything outside the process — including the client that has to agree with it.
+Rename a path and the only thing that notices is a 404 in somebody's browser,
+days later, on the other side of the boundary from the change that caused it.
+
+Making the surface an artifact turns that into a diff.
+
+## Pieces
+
+| Path | Role |
+| --- | --- |
+| `src/routes/inventory.rs` | Declares the surface; tests prove the declaration matches the routers |
+| `src/bin/dump_routes.rs` | Emits it as JSON on stdout |
+| `make routes` | Writes `routes.server.json` |
+| `make routes-check` | Runs the parity tests alone |
+
+## Usage
+
+```sh
+# sqlx checks queries at compile time, so building needs a migrated database
+DATABASE_URL="sqlite://$PWD/dev.db" make routes
+```
+
+Then copy `routes.server.json` into the client repo at
+`packages/contract-harness/routes.server.json` and run `pnpm contract:drift`
+there. The diff on that file is the reviewable record of what moved.
+
+## The declaration is checked, not trusted
+
+A hand-maintained list of routes rots exactly as fast as the thing it describes,
+so `ROUTES` is not taken on faith.
+
+`inventory_matches_route_sources` parses the sibling `routes/*.rs` sources at
+compile time (via `include_str!`) and asserts set equality with the declaration,
+in both directions:
+
+- a `.route(...)` call that nobody declared fails the test — otherwise the
+  client harness would be blind to that route;
+- a declared route with no matching call also fails — otherwise the harness
+  tests something that no longer exists and reports its 404 as a client bug.
+
+Three further tests guard the checker's own blind spots: `module_coverage`
+(a route module missing from `SOURCES` would contribute zero routes and pass
+silently), `every_source_contributes_routes` (a stale `include_str!` path that
+still compiles), and `no_duplicate_method_path_pairs` (axum panics at startup on
+a duplicate registration — better as a test failure than a boot crash).
+
+The check is source-level on purpose. Verifying against a live `Router` would
+need a fully built `AppState` — SQLite, NATS, Google clients — which would make
+the cheapest invariant in the crate the most expensive one to run.
+
+## Adding a route
+
+1. Register it in the relevant `src/routes/*.rs` as usual.
+2. Add the matching `RouteDescriptor` to `ROUTES` in `src/routes/inventory.rs`.
+   The test tells you if you forget, and tells you exactly which route.
+3. Regenerate the snapshot and copy it to the client repo.
+
+A whole new route module also needs an entry in the `SOURCES` table inside the
+test module, otherwise its routes are unaudited.
+
+## Schema versioning
+
+`INVENTORY_SCHEMA_VERSION` is emitted in the JSON. Bump it when the shape
+changes in a way consumers must react to — the client harness refuses a snapshot
+version it does not recognise rather than misreading one.

--- a/apps/servers/file_host/src/bin/dump_routes.rs
+++ b/apps/servers/file_host/src/bin/dump_routes.rs
@@ -1,0 +1,29 @@
+//! Emits the server's HTTP surface as JSON on stdout.
+//!
+//! ```sh
+//! cargo run -q --bin dump-routes > routes.server.json
+//! ```
+//!
+//! The client repo checks that file in (`packages/contract-harness/`) and
+//! diffs its contracts against it, so a route rename on this side shows up
+//! there as a failing drift check rather than a 404 in the browser.
+//!
+//! Deliberately does not touch [`file_host::Config`]: the real server requires
+//! `HMAC_KEY` and a database before it will start, and needing a provisioned
+//! environment just to ask "what paths do you serve?" would make this too
+//! annoying to run, which would make the snapshot stale, which would make the
+//! whole check worthless.
+
+use file_host::routes::inventory;
+use std::io::{self, Write};
+
+fn main() -> io::Result<()> {
+	let stdout = io::stdout();
+	let mut out = stdout.lock();
+
+	// `to_writer_pretty` rather than `to_string`: `clippy.toml` disallows the
+	// latter, and streaming avoids materialising the document twice.
+	serde_json::to_writer_pretty(&mut out, &inventory::snapshot()).map_err(io::Error::other)?;
+	out.write_all(b"\n")?;
+	out.flush()
+}

--- a/apps/servers/file_host/src/main.rs
+++ b/apps/servers/file_host/src/main.rs
@@ -1,9 +1,9 @@
-mod handlers;
-mod metrics;
-mod models;
-mod routes;
-
-use crate::routes::{
+// These modules live in the library crate (`src/lib.rs`) and are used from
+// there rather than re-declared here. Declaring `mod routes;` compiled a second
+// copy of the whole tree into this binary, which meant anything the binary did
+// not happen to call — the route inventory, for one — tripped `dead_code` under
+// `-D warnings` despite being used by the library's other consumers.
+use file_host::routes::{
 	audio_files::get_audio,
 	db::{mood_events, tabs},
 	gdrive::{get_gdrive_image, write_gdrive_fs},
@@ -17,11 +17,7 @@ use anyhow::Result;
 use axum::{error_handling::HandleErrorLayer, middleware::from_fn_with_state, Router};
 use clap::Parser;
 use file_host::rate_limiter::token_bucket::rate_limit_middleware;
-use file_host::{
-	error::{FileHostError, GSheetDeriveError},
-	perform_health_check, AppState, AudioServiceError, Config, DedupCache, API_V1_BASE_PATH,
-};
-use sdk::ReadDrive;
+use file_host::{error::FileHostError, perform_health_check, AppState, Config, API_V1_BASE_PATH};
 use some_services::rate_limiter::TokenBucketRateLimiter;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 use std::{net::SocketAddr, str::FromStr, sync::Arc};

--- a/apps/servers/file_host/src/rate_limiter/sliding_window.rs
+++ b/apps/servers/file_host/src/rate_limiter/sliding_window.rs
@@ -53,13 +53,17 @@ pub async fn rate_limit_middleware(State(limiter): State<Arc<SlidingWindowRateLi
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use clap::Parser;
-	use tokio::time::sleep;
+
+	// These tests previously called `new(Arc::new(Config::parse()))` against a
+	// signature that takes `usize`, so the module had not compiled in some
+	// time. Rewritten against the real constructor: the limit is now passed
+	// directly instead of being read out of ambient config, which also makes
+	// the assertions deterministic rather than dependent on whatever
+	// `RATE_LIMIT` happened to be set in the environment.
 
 	#[tokio::test]
-	async fn test_allow_request_within_limit() {
-		dotenv::dotenv().ok();
-		let limiter = SlidingWindowRateLimiter::new(Arc::new(Config::parse()));
+	async fn allows_requests_up_to_the_limit() {
+		let limiter = SlidingWindowRateLimiter::new(3);
 
 		assert!(limiter.allow_request().await);
 		assert!(limiter.allow_request().await);
@@ -67,23 +71,29 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn test_deny_request_exceeding_limit() {
-		let limiter = SlidingWindowRateLimiter::new(Arc::new(Config::parse()));
+	async fn denies_requests_past_the_limit() {
+		let limiter = SlidingWindowRateLimiter::new(2);
 
 		assert!(limiter.allow_request().await);
 		assert!(limiter.allow_request().await);
-		assert!(!limiter.allow_request().await);
+		assert!(!limiter.allow_request().await, "third request should be rejected with a limit of 2");
 	}
 
-	#[tokio::test]
-	async fn test_request_allowed_after_window_expires() {
-		let limiter = SlidingWindowRateLimiter::new(Arc::new(Config::parse()));
+	/// The old version of this test slept two seconds against a sixty-second
+	/// window and asserted the window had expired, so it could only ever have
+	/// failed. Uses tokio's paused clock instead: no wall-clock wait, and it
+	/// advances past the real window rather than a made-up one.
+	#[tokio::test(start_paused = true)]
+	async fn allows_requests_again_once_the_window_expires() {
+		let limiter = SlidingWindowRateLimiter::new(2);
 
 		assert!(limiter.allow_request().await);
 		assert!(limiter.allow_request().await);
 		assert!(!limiter.allow_request().await);
 
-		sleep(Duration::from_secs(2)).await;
-		assert!(limiter.allow_request().await);
+		// Strictly greater than `window_size` - the eviction check is `>`.
+		tokio::time::advance(Duration::from_secs(61)).await;
+
+		assert!(limiter.allow_request().await, "window should have slid past both earlier requests");
 	}
 }

--- a/apps/servers/file_host/src/routes/inventory.rs
+++ b/apps/servers/file_host/src/routes/inventory.rs
@@ -1,0 +1,309 @@
+//! Machine-readable inventory of the HTTP surface `file_host` exposes.
+//!
+//! # Why this exists
+//!
+//! `axum::Router` is write-only: once routes are registered there is no way to
+//! ask it what it accepts. That makes the server's boundary invisible to
+//! anything outside this process — including the client that has to agree with
+//! it. When a path is renamed here, the only thing that notices is a 404 in
+//! somebody's browser, days later.
+//!
+//! This module makes the surface an artifact. `dump-routes` emits it as JSON,
+//! the client repo checks that snapshot into its contract harness, and a
+//! renamed or dropped route shows up as a reviewable diff instead of a runtime
+//! surprise.
+//!
+//! # The declaration is checked, not trusted
+//!
+//! A hand-maintained list of routes rots exactly as fast as the thing it
+//! describes, so this one is not taken on faith. The test at the bottom of this
+//! file parses the sibling `routes/*.rs` sources at compile time (via
+//! `include_str!`) and asserts set equality with what is declared here, in both
+//! directions. Adding a `.route(...)` call without adding it here fails the
+//! test, and so does the reverse.
+//!
+//! That check is source-level on purpose: verifying against a live `Router`
+//! would require a fully built `AppState` (SQLite, NATS, Google clients), which
+//! would make the cheapest invariant in the crate the most expensive one to
+//! run.
+
+use crate::API_V1_BASE_PATH;
+use serde::Serialize;
+
+/// Bump when the emitted JSON shape changes in a way consumers must react to.
+/// The client harness refuses a snapshot it does not know how to read rather
+/// than silently misinterpreting one.
+pub const INVENTORY_SCHEMA_VERSION: u32 = 1;
+
+/// One route as registered on the router, before the `/api/v1` nest is applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RouteDescriptor {
+	/// Uppercase HTTP method, matching the `axum::routing` helper used.
+	pub method: &'static str,
+	/// Path exactly as written in the `.route(...)` call, so the source-parity
+	/// test can compare literals without normalising anything away. Path
+	/// parameters keep their axum `:name` form.
+	pub path: &'static str,
+	/// Whether `main.rs` nests this route under [`API_V1_BASE_PATH`].
+	/// `/health` and `/ws` are the deliberate exceptions.
+	pub versioned: bool,
+	/// The `routes` submodule that registers it. Groups the emitted snapshot
+	/// so a diff reads as "the tabs surface moved", not thirty loose lines.
+	pub module: &'static str,
+}
+
+impl RouteDescriptor {
+	/// The path a client actually has to request, `/api/v1` prefix included.
+	#[must_use]
+	pub fn full_path(&self) -> String {
+		let mut out = String::with_capacity(API_V1_BASE_PATH.len() + self.path.len());
+		if self.versioned {
+			out.push_str(API_V1_BASE_PATH);
+		}
+		out.push_str(self.path);
+		out
+	}
+}
+
+/// The complete surface. Every `.route(...)` call reachable from `main.rs`
+/// appears here exactly once; the source-parity test enforces it.
+///
+/// Ordering is irrelevant — [`snapshot`] sorts before emitting so the JSON is
+/// stable across edits to this list.
+pub const ROUTES: &[RouteDescriptor] = &[
+	// ── unversioned ─────────────────────────────────────────────────────────
+	// Load balancers and orchestrators track these, so they must not move when
+	// the API version bumps. See the doc comment on `API_V1_BASE_PATH`.
+	RouteDescriptor { method: "GET", path: "/health", versioned: false, module: "health" },
+	RouteDescriptor { method: "GET", path: "/ws", versioned: false, module: "websocket" },
+	// ── sheets ──────────────────────────────────────────────────────────────
+	RouteDescriptor { method: "GET", path: "/get_attributions/:sheet_id", versioned: true, module: "sheets" },
+	RouteDescriptor { method: "GET", path: "/get_video_chapters/:sheet_id", versioned: true, module: "sheets" },
+	RouteDescriptor { method: "GET", path: "/get_gantt/:sheet_id", versioned: true, module: "sheets" },
+	RouteDescriptor { method: "GET", path: "/get_nfl_tennis/:sheet_id", versioned: true, module: "sheets" },
+	RouteDescriptor { method: "GET", path: "/get_nfl_roster/:sheet_id", versioned: true, module: "sheets" },
+	// ── gdrive ──────────────────────────────────────────────────────────────
+	RouteDescriptor { method: "GET", path: "/gdrive/image/:image_id", versioned: true, module: "gdrive" },
+	RouteDescriptor { method: "GET", path: "/gdrive/list", versioned: true, module: "gdrive" },
+	RouteDescriptor { method: "GET", path: "/gdrive/list/:folder_id", versioned: true, module: "gdrive" },
+	RouteDescriptor { method: "GET", path: "/gdrive/json/:file_id", versioned: true, module: "gdrive" },
+	RouteDescriptor { method: "PUT", path: "/gdrive/write/:folder_id/:name", versioned: true, module: "gdrive" },
+	// ── github ──────────────────────────────────────────────────────────────
+	RouteDescriptor { method: "GET", path: "/get_github_repos", versioned: true, module: "github" },
+	// ── mood events ─────────────────────────────────────────────────────────
+	RouteDescriptor { method: "POST", path: "/mood_events", versioned: true, module: "mood_events" },
+	RouteDescriptor { method: "GET", path: "/mood_events", versioned: true, module: "mood_events" },
+	RouteDescriptor { method: "GET", path: "/mood_events/:id", versioned: true, module: "mood_events" },
+	RouteDescriptor { method: "PATCH", path: "/mood_events/:id", versioned: true, module: "mood_events" },
+	RouteDescriptor { method: "DELETE", path: "/mood_events/:id", versioned: true, module: "mood_events" },
+	RouteDescriptor { method: "POST", path: "/mood_events/batch", versioned: true, module: "mood_events" },
+	RouteDescriptor { method: "PATCH", path: "/mood_events/batch", versioned: true, module: "mood_events" },
+	RouteDescriptor { method: "DELETE", path: "/mood_events/batch", versioned: true, module: "mood_events" },
+	RouteDescriptor { method: "GET", path: "/mood_events/week/:week", versioned: true, module: "mood_events" },
+	RouteDescriptor { method: "GET", path: "/mood_events/team/:team", versioned: true, module: "mood_events" },
+	RouteDescriptor { method: "GET", path: "/mood_events/stats", versioned: true, module: "mood_events" },
+	// ── tabs ────────────────────────────────────────────────────────────────
+	RouteDescriptor { method: "POST", path: "/tabs", versioned: true, module: "tabs" },
+	RouteDescriptor { method: "GET", path: "/tabs", versioned: true, module: "tabs" },
+	RouteDescriptor { method: "GET", path: "/tabs/:tab_id", versioned: true, module: "tabs" },
+	RouteDescriptor { method: "DELETE", path: "/tabs/:tab_id", versioned: true, module: "tabs" },
+	RouteDescriptor { method: "POST", path: "/tabs/batch", versioned: true, module: "tabs" },
+	RouteDescriptor { method: "DELETE", path: "/tabs/batch", versioned: true, module: "tabs" },
+	RouteDescriptor { method: "POST", path: "/tabs/prune", versioned: true, module: "tabs" },
+	RouteDescriptor { method: "POST", path: "/tabs/reconcile", versioned: true, module: "tabs" },
+	RouteDescriptor { method: "GET", path: "/tabs/summaries", versioned: true, module: "tabs" },
+	RouteDescriptor { method: "POST", path: "/tabs/pipeline", versioned: true, module: "tabs" },
+	// ── audio ───────────────────────────────────────────────────────────────
+	RouteDescriptor { method: "GET", path: "/get_audio/:id", versioned: true, module: "audio_files" },
+	RouteDescriptor { method: "GET", path: "/search_audio", versioned: true, module: "audio_files" },
+	RouteDescriptor { method: "POST", path: "/search_audio", versioned: true, module: "audio_files" },
+	// ── misc ────────────────────────────────────────────────────────────────
+	RouteDescriptor { method: "POST", path: "/now-playing", versioned: true, module: "tab_metadata" },
+	RouteDescriptor { method: "POST", path: "/utter", versioned: true, module: "utterance" },
+];
+
+/// One route in the emitted JSON. Carries `full_path` already resolved so
+/// consumers never have to reimplement the `/api/v1` nesting rule.
+#[derive(Debug, Clone, Serialize)]
+pub struct RouteEntry {
+	pub method: String,
+	pub path: String,
+	pub full_path: String,
+	pub versioned: bool,
+	pub module: String,
+}
+
+/// The emitted document.
+#[derive(Debug, Clone, Serialize)]
+pub struct RouteInventory {
+	pub schema_version: u32,
+	pub api_base_path: String,
+	/// Server crate version, so a snapshot can be traced back to a build.
+	pub server_version: String,
+	pub routes: Vec<RouteEntry>,
+}
+
+/// Builds the emittable snapshot, sorted so that regenerating it without
+/// changing any route produces a byte-identical file.
+#[must_use]
+pub fn snapshot() -> RouteInventory {
+	let mut routes: Vec<RouteEntry> = ROUTES
+		.iter()
+		.map(|route| RouteEntry {
+			method: route.method.to_owned(),
+			path: route.path.to_owned(),
+			full_path: route.full_path(),
+			versioned: route.versioned,
+			module: route.module.to_owned(),
+		})
+		.collect();
+
+	routes.sort_by(|a, b| a.module.cmp(&b.module).then_with(|| a.path.cmp(&b.path)).then_with(|| a.method.cmp(&b.method)));
+
+	RouteInventory {
+		schema_version: INVENTORY_SCHEMA_VERSION,
+		api_base_path: API_V1_BASE_PATH.to_owned(),
+		server_version: env!("CARGO_PKG_VERSION").to_owned(),
+		routes,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{RouteDescriptor, ROUTES};
+	use regex::Regex;
+	use std::collections::BTreeSet;
+
+	/// Every source file that registers routes, paired with the module name
+	/// used in [`ROUTES`] and whether `main.rs` nests it under `/api/v1`.
+	///
+	/// Adding a new `routes/*.rs` module means adding it here too — otherwise
+	/// its routes are unaudited. The `module_coverage` test below catches the
+	/// half of that mistake it can see.
+	const SOURCES: &[(&str, &str, bool)] = &[
+		("health", include_str!("health.rs"), false),
+		("websocket", include_str!("../websocket.rs"), false),
+		("sheets", include_str!("sheets.rs"), true),
+		("gdrive", include_str!("gdrive.rs"), true),
+		("github", include_str!("github.rs"), true),
+		("mood_events", include_str!("db/hopium.rs"), true),
+		("tabs", include_str!("db/tab.rs"), true),
+		("audio_files", include_str!("audio_files.rs"), true),
+		("tab_metadata", include_str!("tab_metadata.rs"), true),
+		("utterance", include_str!("utterance.rs"), true),
+	];
+
+	/// A route as recovered from source: `(module, METHOD, path, versioned)`.
+	type ParsedRoute = (String, String, String, bool);
+
+	/// Recovers every `.route("<path>", <method>(...))` registration from the
+	/// sources above.
+	///
+	/// This reads the literal text rather than the built router, which means it
+	/// sees what a reviewer sees. The one thing it cannot see is a route
+	/// registered somewhere not listed in `SOURCES` — hence `module_coverage`.
+	fn parse_sources() -> BTreeSet<ParsedRoute> {
+		let pattern = Regex::new(r#"\.route\(\s*"([^"]+)"\s*,\s*(get|post|put|patch|delete)\("#).unwrap();
+
+		let mut found = BTreeSet::new();
+		for (module, source, versioned) in SOURCES {
+			for capture in pattern.captures_iter(source) {
+				let path = capture.get(1).unwrap().as_str().to_owned();
+				let method = capture.get(2).unwrap().as_str().to_uppercase();
+				found.insert(((*module).to_owned(), method, path, *versioned));
+			}
+		}
+		found
+	}
+
+	fn declared() -> BTreeSet<ParsedRoute> {
+		ROUTES
+			.iter()
+			.map(|route: &RouteDescriptor| ((route.module).to_owned(), (route.method).to_owned(), (route.path).to_owned(), route.versioned))
+			.collect()
+	}
+
+	/// The load-bearing invariant: the declaration and the router agree.
+	///
+	/// Both directions matter. A route in source but not declared means the
+	/// client harness is blind to it. A route declared but not in source means
+	/// the harness is testing something that no longer exists, and will report
+	/// a 404 as a client bug.
+	#[test]
+	fn inventory_matches_route_sources() {
+		let in_source = parse_sources();
+		let in_inventory = declared();
+
+		let undeclared: Vec<_> = in_source.difference(&in_inventory).collect();
+		let phantom: Vec<_> = in_inventory.difference(&in_source).collect();
+
+		assert!(
+			undeclared.is_empty(),
+			"routes registered in source but missing from ROUTES — add them, or the contract harness cannot see them: {undeclared:#?}"
+		);
+		assert!(
+			phantom.is_empty(),
+			"routes declared in ROUTES but absent from source — they were renamed or removed; update ROUTES and regenerate the client snapshot: {phantom:#?}"
+		);
+	}
+
+	/// Guards the blind spot in `parse_sources`: a `routes/*.rs` module that
+	/// nobody added to `SOURCES` would silently contribute zero routes and the
+	/// parity test would still pass.
+	#[test]
+	fn module_coverage() {
+		let source_modules: BTreeSet<&str> = SOURCES.iter().map(|(module, _, _)| *module).collect();
+		let declared_modules: BTreeSet<&str> = ROUTES.iter().map(|route| route.module).collect();
+
+		assert_eq!(
+			source_modules, declared_modules,
+			"SOURCES and ROUTES disagree about which modules exist; a whole route module is probably unaudited"
+		);
+	}
+
+	/// Each `SOURCES` entry must actually yield routes. Catches a stale
+	/// `include_str!` path that still compiles but points at a file which no
+	/// longer registers anything.
+	#[test]
+	fn every_source_contributes_routes() {
+		let parsed = parse_sources();
+		for (module, _, _) in SOURCES {
+			assert!(
+				parsed.iter().any(|(parsed_module, _, _, _)| parsed_module == module),
+				"source module `{module}` parsed to zero routes — wrong include_str! path, or the routes moved"
+			);
+		}
+	}
+
+	#[test]
+	fn versioned_routes_carry_the_api_prefix() {
+		for route in ROUTES {
+			let full = route.full_path();
+			if route.versioned {
+				assert!(full.starts_with("/api/v1/"), "versioned route {} did not resolve under /api/v1: {full}", route.path);
+			} else {
+				assert!(!full.starts_with("/api/v1"), "unversioned route {} unexpectedly resolved under /api/v1: {full}", route.path);
+			}
+		}
+	}
+
+	/// `main.rs` merges these routers into one `Router`; axum panics at startup
+	/// on a duplicate method+path. Catching it here turns a boot-time crash into
+	/// a test failure.
+	#[test]
+	fn no_duplicate_method_path_pairs() {
+		let mut seen = BTreeSet::new();
+		for route in ROUTES {
+			let key = (route.method, route.full_path());
+			assert!(seen.insert(key), "duplicate route registration: {} {}", route.method, route.full_path());
+		}
+	}
+
+	#[test]
+	fn snapshot_is_deterministic() {
+		let first = super::snapshot();
+		let second = super::snapshot();
+		let rendered = |inventory: &super::RouteInventory| serde_json::to_string_pretty(inventory).unwrap();
+		assert_eq!(rendered(&first), rendered(&second));
+	}
+}

--- a/apps/servers/file_host/src/routes/mod.rs
+++ b/apps/servers/file_host/src/routes/mod.rs
@@ -4,6 +4,7 @@ pub mod db;
 pub mod gdrive;
 pub mod github;
 pub mod health;
+pub mod inventory;
 pub mod sheets;
 pub mod tab_metadata;
 pub mod utterance;


### PR DESCRIPTION
## Description

This PR introduces a machine-readable inventory of the `file_host` server's HTTP surface to enable contract testing with the client repository. The inventory is checked at compile time against the actual route registrations to prevent drift between declared and implemented routes.

### Key Changes

1. **New `src/routes/inventory.rs` module**: Declares all HTTP routes with metadata (method, path, versioning, module). Includes compile-time tests that:
   - Parse route registrations from source files via `include_str!`
   - Assert bidirectional parity between declarations and implementations
   - Guard against blind spots (missing modules, stale includes, duplicates)
   - Verify versioning rules are applied correctly

2. **New `src/bin/dump_routes.rs` binary**: Emits the route inventory as JSON without requiring a fully provisioned environment (no database, HMAC key, or external services needed).

3. **Documentation**: Added `docs/route-inventory.md` explaining the system, usage, and how to add new routes.

4. **Build integration**: Added `make routes` and `make routes-check` targets to regenerate and validate the inventory.

5. **Fixed `src/main.rs`**: Changed from declaring `mod routes` to using `use file_host::routes` to avoid compiling the route tree twice, which was causing `dead_code` warnings for the inventory module.

6. **Fixed rate limiter tests**: Rewrote three broken tests in `src/rate_limiter/sliding_window.rs` that were calling a non-existent constructor signature. Now use the real constructor and tokio's paused clock for deterministic timing.

7. **Updated `Cargo.toml`**: Added explicit binary declarations and dev-dependencies for test utilities.

### Why This Matters

`axum::Router` is write-only—once routes are registered, there's no way to query what it accepts. Route renames only surface as 404s in the browser, days after deployment. This inventory makes the HTTP boundary an auditable artifact that shows up as a reviewable diff in the client repo's contract harness.

## Type of change

- [x] New feature (adds route inventory system)
- [x] Bug fix (fixes broken rate limiter tests)
- [x] Documentation update

## How Has This Been Tested?

- Compile-time tests in `src/routes/inventory.rs` verify route declarations match implementations
- Rate limiter tests rewritten and now pass with deterministic timing
- `cargo test -p file_host --lib routes::inventory` validates the entire system
- `cargo run -q --bin dump-routes` successfully emits JSON without requiring full environment setup

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed for correctness
- [x] Added comprehensive documentation in code and docs/
- [x] No new warnings generated
- [x] Added/fixed tests that verify the feature works
- [x] Existing tests pass locally

## Additional Notes

The route inventory is designed to be consumed by the client repo (`paulgsc/some-ui`) at `packages/contract-harness/routes.server.json`. The client's contract harness diffs its HTTP requests against this snapshot to catch breaking changes at review time rather than runtime.

The compile-time verification approach (parsing source via `include_str!`) was chosen over runtime verification to avoid requiring a fully provisioned environment just to ask "what routes do you serve?"

https://claude.ai/code/session_01FRA1DBALHzfo5tZL9ipoaw