### PR TITLE
fix(ci): sqlx multi-crate migration staging + orchestrator cargo-chef --locked

### DIFF
--- a/.github/actions/prepare-sqlx/action.yml
+++ b/.github/actions/prepare-sqlx/action.yml
@@ -18,16 +18,34 @@ runs:
       env:
         DATABASE_URL: sqlite://./dev.db
       run: |
+        set -euo pipefail
         echo "Creating database..."
         mkdir -p "$(dirname ./dev.db)"
         nix develop .#ci --command sqlx database create
 
-        echo "Discovering and running migrations..."
+        # sqlx tracks applied migrations in one `_sqlx_migrations` table per
+        # database. Running `sqlx migrate run --source <dir>` once per crate
+        # against this same dev.db made every crate after the first fail with
+        # "migration ... was previously applied but is missing in the
+        # resolved migrations" — the second invocation's --source doesn't
+        # contain the first crate's migration files, so sqlx's own
+        # already-applied bookkeeping no longer resolves. One shared
+        # database needs one shared migrations directory; this stages every
+        # crate's *.up.sql into one before running sqlx once. Mirrors
+        # .github/workflows/test.yml's "Create the database and run every
+        # crate's migrations" step, which solved the same problem the same
+        # way.
+        echo "Staging migrations from every crate..."
+        staged="$(pwd)/.migrations"
+        rm -rf "$staged" && mkdir -p "$staged"
 
-        find crates -type d -name migrations 2>/dev/null | sort | while read migration_dir; do
-          echo "Running migrations from: $migration_dir"
-          nix develop .#ci --command sqlx migrate run --source "$migration_dir"
+        find crates -path '*/migrations/*.up.sql' -type f 2>/dev/null | sort | while read -r migration; do
+          cp "$migration" "$staged/$(basename "$migration" .up.sql).sql"
         done
+
+        echo "Running staged migrations..."
+        nix develop .#ci --command sqlx migrate run --source "$staged"
+        rm -rf "$staged"
 
         echo "All migrations completed successfully"
     # Generate workspace-level .sqlx metadata

--- a/infra/docker/Dockerfile.orchestrator
+++ b/infra/docker/Dockerfile.orchestrator
@@ -3,7 +3,14 @@
 # ==============================================================================
 FROM rust:1.90-bookworm AS chef
 
-RUN cargo install cargo-chef
+# --locked: without it, `cargo install` re-resolves cargo-chef's own
+# dependencies against whatever is newest on crates.io at build time rather
+# than what cargo-chef's release was tested against. That is what broke this
+# build — a newer `cargo-platform` transitive dependency started requiring
+# rustc 1.91, which this pinned 1.90 base doesn't have. Dockerfile.server
+# and Dockerfile.obs already install cargo-chef with --locked; this matches
+# them.
+RUN cargo install cargo-chef --locked
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

Diagnosed why Docker images stopped building/pushing to DockerHub. The `detect.yml` → `build-image.yml` pipeline triggers correctly on every push/PR to `main` (confirmed via live workflow-run history) — the images just fail downstream for three separate, unrelated reasons. This PR fixes the two that are fixable in-repo:

1. **`.github/actions/prepare-sqlx/action.yml`** — looped `sqlx migrate run --source <dir>` once per `crates/*/migrations` directory against one shared `dev.db`. sqlx's `_sqlx_migrations` bookkeeping is per-database, not per-`--source`, so as soon as a second migrations directory existed, the second crate's run failed with `migration ... was previously applied but is missing in the resolved migrations`. Confirmed this started failing 2026-06-29, one day after `crates/db/capture/migrations` joined the pre-existing `crates/db/mood_event/migrations` (commit 53efe15) — now 5 directories collide. Fixed by staging every crate's `*.up.sql` into one directory first, then running `sqlx migrate run` once — the same pattern `.github/workflows/test.yml`'s "Create the database and run every crate's migrations" step already uses successfully.

2. **`infra/docker/Dockerfile.orchestrator`** — installed `cargo-chef` without `--locked`, so it re-resolved cargo-chef's own dependencies against crates.io at build time. A newer `cargo-platform` transitive dependency now requires rustc 1.91+, which the pinned `rust:1.90-bookworm` base doesn't have (`error: rustc 1.90.0 is not supported by cargo-platform@0.3.3`). `Dockerfile.server` and `Dockerfile.obs` already install cargo-chef with `--locked` and build fine on the same base image — this just matches them.

**Not fixed here, and can't be from a code change**: DockerHub auth itself. `docker/login-action` has failed with `unauthorized: incorrect username or password` on every push to `main` since 2026-06-29 — it worked as recently as 2026-04-05, so the `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` repo secret most likely needs rotating on DockerHub's side and in repo settings. That's outside what this PR can address.

## How this was verified

- `.github/actions/prepare-sqlx/action.yml`'s embedded script: YAML-parsed and the extracted bash validated with `bash -n` (syntax only — no `nix`/`sqlx` available to actually run it in this environment; it mirrors `test.yml`'s already-working equivalent step line for line in approach).
- `infra/docker/Dockerfile.orchestrator`: confirmed by diffing against `Dockerfile.server`/`Dockerfile.obs`, which already carry the `--locked` flag and build successfully on the identical `rust:1.90-bookworm` base — no docker daemon available in this environment to build the image directly.
- Root-caused via live GitHub Actions run history and job logs (`mcp__github__` tools), not just static reading — cited specific run IDs and dates during investigation.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have performed a self-review of my own code
- [ ] Verified by an actual CI run building these images (will confirm once this PR's own CI runs, and recommend watching the next push-to-main build)


---
_Generated by [Claude Code](https://claude.ai/code/session_0127Q1cND2S99KDuMQWTQZhB)_