### PR TITLE
Fault conditions: /ready, HTTP+refusal metrics, build identity, HEALTH row

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -20,6 +20,14 @@ inputs:
   dockerhub-token:
     description: "DockerHub token (required if push=true)"
     required: false
+  vcs-ref:
+    description: "Git commit SHA to stamp into the image (OCI label and, for images whose build.rs reads it, the running binary's own service_info metric)"
+    required: false
+    default: "unknown"
+  build-date:
+    description: "RFC 3339 build timestamp to stamp into the image, same reasoning as vcs-ref"
+    required: false
+    default: "unknown"
 runs:
   using: composite
   steps:
@@ -40,5 +48,9 @@ runs:
         tags: |
           ${{ inputs.docker-repo }}:latest
           ${{ inputs.docker-repo }}:${{ github.sha }}
+        build-args: |
+          VCS_REF=${{ inputs.vcs-ref }}
+          BUILD_DATE=${{ inputs.build-date }}
+          APP_NAME=${{ inputs.image-name }}
         cache-from: type=gha,scope=${{ inputs.image-name }}
         cache-to: type=gha,mode=max,scope=${{ inputs.image-name }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Compute build date
+        id: build_date
+        run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
       - name: Prepare SQLx environment
         if: matrix.needs_sqlx || matrix.needs_migrations
         uses: ./.github/actions/prepare-sqlx
@@ -39,3 +42,9 @@ jobs:
           push: ${{ inputs.push }}
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          # #213 (F4): file_host's build.rs reads these same names (VCS_REF,
+          # BUILD_DATE) to stamp the `service_info` metric it exposes at
+          # runtime — see infra/docker/Dockerfile.server's builder stage.
+          # Harmless for images that don't read them.
+          vcs-ref: ${{ github.sha }}
+          build-date: ${{ steps.build_date.outputs.value }}

--- a/apps/servers/file_host/build.rs
+++ b/apps/servers/file_host/build.rs
@@ -1,0 +1,128 @@
+//! Stamps build identity into compile-time env vars — see #213 (F4).
+//!
+//! `handlers::readiness`/`metrics::instruments` read these back via
+//! `env!(...)`. The point: `docker compose up -d` after a code change that
+//! failed to rebuild leaves the old image running, and the dashboard looks
+//! identical either way — the metric you just added being absent reads as
+//! "the feature isn't firing" rather than "you're looking at yesterday's
+//! binary". `service_info`'s `git_sha` label is what tells them apart.
+//!
+//! Prefers `VCS_REF`/`GIT_DIRTY`/`BUILD_DATE` env vars when set — that's the
+//! path a Docker build takes, since `.git` isn't copied into any of this
+//! workspace's build contexts (see `infra/docker/Dockerfile.server`) and
+//! `git` genuinely isn't answerable in there. Falls back to running `git`
+//! directly, which is what a local `cargo build`/`cargo test` gets: `.git`
+//! is right there, and CI's `actions/checkout` provides it too. Either way,
+//! absence is `"unknown"`, never a build failure — a missing identity
+//! string is not a reason to refuse to compile the binary that would
+//! report it.
+
+// A build script talks to cargo over stdout by protocol — `cargo:rustc-env=…`
+// lines are how this file's whole job gets done, not a logging shortcut the
+// workspace's tracing-only convention has an alternative for.
+#![allow(clippy::disallowed_macros)]
+
+use std::env;
+use std::process::Command;
+
+fn main() {
+	println!("cargo:rerun-if-changed=migrations");
+	println!("cargo:rerun-if-changed=../../../.git/HEAD");
+	println!("cargo:rerun-if-env-changed=VCS_REF");
+	println!("cargo:rerun-if-env-changed=GIT_DIRTY");
+	println!("cargo:rerun-if-env-changed=BUILD_DATE");
+
+	// `VCS_REF`/`BUILD_DATE`: the same names `infra/docker/Dockerfile.server`
+	// already declared as `ARG`s for its OCI `LABEL`s (previously wired to
+	// the runtime stage only, so those labels were always literally
+	// "unknown" — see `.github/actions/docker-build/action.yml`, which now
+	// passes them as build args reaching this stage too). Reusing the names
+	// means one git-derived value backs both the image's own metadata and
+	// what the running binary reports about itself, rather than two
+	// independent, driftable sources for the same fact.
+	let git_sha = env::var("VCS_REF").ok().filter(|v| !v.is_empty() && v != "unknown").unwrap_or_else(|| git(&["rev-parse", "--short=12", "HEAD"]).unwrap_or_else(|| "unknown".to_string()));
+
+	let dirty = env::var("GIT_DIRTY").ok().filter(|v| !v.is_empty()).unwrap_or_else(|| {
+		if git(&["status", "--porcelain"]).is_some_and(|s| !s.trim().is_empty()) {
+			"dirty".to_string()
+		} else {
+			"clean".to_string()
+		}
+	});
+
+	let built_at = env::var("BUILD_DATE").ok().filter(|v| !v.is_empty() && v != "unknown").unwrap_or_else(|| {
+		// `SOURCE_DATE_EPOCH`-independent: a build timestamp, unlike a git
+		// SHA, has no reproducible-builds convention to defer to here, and
+		// "when this binary was actually compiled" is exactly what F4 wants.
+		humantime_seconds_now()
+	});
+
+	let rustc_version = Command::new(env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string()))
+		.arg("--version")
+		.output()
+		.ok()
+		.filter(|o| o.status.success())
+		.and_then(|o| String::from_utf8(o.stdout).ok())
+		.map_or_else(|| "unknown".to_string(), |s| s.trim().to_string());
+
+	println!("cargo:rustc-env=GIT_SHA={git_sha}");
+	println!("cargo:rustc-env=GIT_DIRTY={dirty}");
+	println!("cargo:rustc-env=BUILD_TIMESTAMP={built_at}");
+	println!("cargo:rustc-env=RUSTC_VERSION={rustc_version}");
+}
+
+fn git(args: &[&str]) -> Option<String> {
+	let output = Command::new("git").args(args).output().ok()?;
+	if !output.status.success() {
+		return None;
+	}
+	let text = String::from_utf8(output.stdout).ok()?;
+	let trimmed = text.trim();
+	(!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// An RFC 3339 UTC timestamp without pulling in a `chrono`/`time` build
+/// dependency just for this — `build.rs` runs on the host doing the
+/// compiling, so `SystemTime::now()` plus fixed civil-calendar arithmetic is
+/// enough; leap seconds are not a concern at "which day was this built" a
+/// resolution.
+///
+/// `days as i64`: `days` is `secs / 86_400` off the current wall clock —
+/// nowhere near `i64::MAX` days since the epoch, so this cannot wrap in
+/// practice; see `civil_from_days`'s own doc comment for the same allowance.
+#[allow(clippy::cast_possible_wrap)]
+fn humantime_seconds_now() -> String {
+	let secs = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
+
+	let days = secs / 86_400;
+	let time_of_day = secs % 86_400;
+	let (hour, minute, second) = (time_of_day / 3600, (time_of_day % 3600) / 60, time_of_day % 60);
+
+	let (year, month, day) = civil_from_days(days as i64);
+	format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+/// Howard Hinnant's `civil_from_days`: days-since-epoch to a proleptic
+/// Gregorian (year, month, day), valid over the entire range `i64` can
+/// represent. <https://howardhinnant.github.io/date_algorithms.html>
+///
+/// The `i64`/`u64`/`u32` casts throughout are the algorithm's own —
+/// `doe`/`yoe`/`doy`/`mp` are always non-negative by construction (each is a
+/// remainder or difference bounded within one 400-year era), and `d`/`m` are
+/// calendar day-of-month/month numbers, always small. None of clippy's
+/// pedantic cast lints can see those invariants, so they're allowed here
+/// rather than restructured with fallible `try_from` a build script's
+/// bounded, always-in-range date math doesn't need.
+#[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+const fn civil_from_days(z: i64) -> (i64, u32, u32) {
+	let z = z + 719_468;
+	let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+	let doe = (z - era * 146_097) as u64;
+	let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+	let y = yoe as i64 + era * 400;
+	let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+	let mp = (5 * doy + 2) / 153;
+	let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+	let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+	(if m <= 2 { y + 1 } else { y }, m, d)
+}

--- a/apps/servers/file_host/src/handlers/mod.rs
+++ b/apps/servers/file_host/src/handlers/mod.rs
@@ -7,6 +7,7 @@ pub mod health;
 pub mod pipeline;
 pub mod push;
 pub mod read_sheets;
+pub mod readiness;
 pub mod signals;
 pub mod tab_metadata;
 pub mod utterance;

--- a/apps/servers/file_host/src/handlers/readiness.rs
+++ b/apps/servers/file_host/src/handlers/readiness.rs
@@ -1,0 +1,140 @@
+//! `GET /ready` — can this process serve, not just answer a socket?
+//!
+//! See #213 (F1). `/health` (`handlers::health`) is a liveness probe: it
+//! consults nothing and is correct as long as the runtime is scheduling.
+//! This is the readiness half of that split — it checks every dependency
+//! `AppState` actually holds a handle to (`SQLite`, NATS, Redis) and answers
+//! 503 with a per-dependency breakdown when any of them is unreachable.
+//!
+//! Every check that can actually block is bounded by
+//! [`DEPENDENCY_CHECK_TIMEOUT`] and run concurrently: a readiness probe
+//! that hangs waiting on one dependency is worse than one that answers
+//! "not ready" promptly, and there is no reason a slow `SQLite` lock should
+//! delay finding out Redis is also down. NATS's check is a non-blocking
+//! state read (see `check_nats`) with nothing to bound or join.
+
+use crate::metrics::build_info;
+use crate::AppState;
+use axum::{extract::State, http::StatusCode, response::Json};
+use metrics::gauge;
+use serde::Serialize;
+use sqlx::SqlitePool;
+use std::time::Duration;
+use tracing::instrument;
+
+/// Bounds each of the two checks that can actually block (`SQLite`, Redis).
+/// Well under the 15s `TASK_TIMEOUT_MS` request timeout even run
+/// sequentially — run concurrently (as they are here) the whole handler
+/// resolves in one dependency's worth of this budget, not the sum of two.
+const DEPENDENCY_CHECK_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Serialize)]
+struct DependencyStatus {
+	name: &'static str,
+	healthy: bool,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ReadinessResponse {
+	ready: bool,
+	service: &'static str,
+	version: &'static str,
+	// #213 (F4): the same identity `service_info` carries, duplicated here
+	// so the answer survives Prometheus being down — the dashboard must not
+	// be the only source of truth for which build is running.
+	git_sha: String,
+	built_at: &'static str,
+	rust: &'static str,
+	dependencies: Vec<DependencyStatus>,
+}
+
+#[axum::debug_handler]
+#[instrument(name = "readiness", skip_all)]
+pub async fn readiness(State(state): State<AppState>) -> (StatusCode, Json<ReadinessResponse>) {
+	// `check_nats` is synchronous (a non-blocking state read, not a
+	// round-trip — see its own doc comment), so it isn't part of the join;
+	// only the two checks that can actually await something are run
+	// concurrently.
+	let nats = check_nats(&state);
+	let (sqlite, redis) = tokio::join!(check_sqlite(&state.core.shared_db), check_redis(&state));
+
+	// A gauge per dependency, not just the aggregate `ready` bool — #225's
+	// DEPS panel needs to name which one is down, not just that something is.
+	gauge!("dependency_up", "dependency" => "sqlite").set(f64::from(sqlite.healthy));
+	gauge!("dependency_up", "dependency" => "nats").set(f64::from(nats.healthy));
+	gauge!("dependency_up", "dependency" => "redis").set(f64::from(redis.healthy));
+
+	let ready = sqlite.healthy && nats.healthy && redis.healthy;
+	let status = if ready { StatusCode::OK } else { StatusCode::SERVICE_UNAVAILABLE };
+
+	(
+		status,
+		Json(ReadinessResponse {
+			ready,
+			service: build_info::SERVICE,
+			version: env!("CARGO_PKG_VERSION"),
+			git_sha: build_info::git_sha_with_dirty_marker(),
+			built_at: build_info::BUILT_AT,
+			rust: build_info::RUSTC_VERSION,
+			dependencies: vec![sqlite, nats, redis],
+		}),
+	)
+}
+
+async fn check_sqlite(pool: &SqlitePool) -> DependencyStatus {
+	let result = tokio::time::timeout(DEPENDENCY_CHECK_TIMEOUT, sqlx::query("SELECT 1").fetch_one(pool)).await;
+	match result {
+		Ok(Ok(_)) => DependencyStatus { name: "sqlite", healthy: true, error: None },
+		Ok(Err(e)) => DependencyStatus {
+			name: "sqlite",
+			healthy: false,
+			error: Some(e.to_string()),
+		},
+		Err(_) => DependencyStatus {
+			name: "sqlite",
+			healthy: false,
+			error: Some("check did not complete within ".to_string() + &DEPENDENCY_CHECK_TIMEOUT.as_secs().to_string() + "s"),
+		},
+	}
+}
+
+/// A non-blocking connection-state read, not a round-trip — see
+/// `NatsTransport::is_connected`'s own doc comment for why that is the
+/// correct trade-off for a readiness probe. Nothing here can hang, so it
+/// does not need `DEPENDENCY_CHECK_TIMEOUT`.
+fn check_nats(state: &AppState) -> DependencyStatus {
+	if state.realtime.transport.is_connected() {
+		DependencyStatus { name: "nats", healthy: true, error: None }
+	} else {
+		DependencyStatus {
+			name: "nats",
+			healthy: false,
+			error: Some("connection not established".to_string()),
+		}
+	}
+}
+
+async fn check_redis(state: &AppState) -> DependencyStatus {
+	let client = state.realtime.dedup_cache.store().redis_client().clone();
+	let result = tokio::time::timeout(DEPENDENCY_CHECK_TIMEOUT, async move {
+		let mut conn = client.get_multiplexed_async_connection().await?;
+		redis::cmd("PING").query_async::<String>(&mut conn).await
+	})
+	.await;
+
+	match result {
+		Ok(Ok(_)) => DependencyStatus { name: "redis", healthy: true, error: None },
+		Ok(Err(e)) => DependencyStatus {
+			name: "redis",
+			healthy: false,
+			error: Some(e.to_string()),
+		},
+		Err(_) => DependencyStatus {
+			name: "redis",
+			healthy: false,
+			error: Some("check did not complete within ".to_string() + &DEPENDENCY_CHECK_TIMEOUT.as_secs().to_string() + "s"),
+		},
+	}
+}

--- a/apps/servers/file_host/src/health.rs
+++ b/apps/servers/file_host/src/health.rs
@@ -1,23 +1,30 @@
 use crate::Config;
 use anyhow::Result;
 
+/// The `--health-check` CLI flag's target, invoked by `infra/compose/file_host.yml`'s
+/// container healthcheck (`file_host --health-check`). Deliberately `/ready`,
+/// not `/health` — see #213 (F1). This is what `depends_on: condition:
+/// service_healthy` gates on elsewhere in the compose stack, so it needs to
+/// mean "can serve", not merely "the process answers a socket". The flag
+/// keeps its name (external scripts and this compose file already invoke it)
+/// even though its target moved; only the request behind it changed.
 pub async fn perform_health_check(config: &Config) -> Result<()> {
 	use std::process;
 
-	let url = format!("http://{}:{}/health", config.health_check_host, config.health_check_port);
+	let url = format!("http://{}:{}/ready", config.health_check_host, config.health_check_port);
 
 	match reqwest::Client::new().get(&url).timeout(std::time::Duration::from_secs(10)).send().await {
 		Ok(response) => {
 			if response.status().is_success() {
-				println!("Health check passed");
+				println!("Readiness check passed");
 				process::exit(0);
 			} else {
-				eprintln!("Health check failed: HTTP {}", response.status());
+				eprintln!("Readiness check failed: HTTP {}", response.status());
 				process::exit(1);
 			}
 		}
 		Err(e) => {
-			eprintln!("Health check failed: {}", e);
+			eprintln!("Readiness check failed: {}", e);
 			process::exit(1);
 		}
 	}

--- a/apps/servers/file_host/src/main.rs
+++ b/apps/servers/file_host/src/main.rs
@@ -4,8 +4,13 @@
 // not happen to call — the route inventory, for one — tripped `dead_code` under
 // `-D warnings` despite being used by the library's other consumers.
 use anyhow::Result;
-use axum::{error_handling::HandleErrorLayer, middleware::from_fn_with_state, Router};
+use axum::{
+	error_handling::HandleErrorLayer, extract::Request as AxumRequest, http::StatusCode, middleware::from_fn, middleware::from_fn_with_state, middleware::Next, response::Response,
+	Router,
+};
 use clap::Parser;
+use file_host::metrics::http::{track_http_metrics, unmatched, HTTP_DURATION_BUCKETS, HTTP_DURATION_METRIC};
+use file_host::metrics::refusals;
 use file_host::rate_limiter::token_bucket::rate_limit_middleware;
 use file_host::routes::{
 	audio_files::get_audio,
@@ -15,6 +20,7 @@ use file_host::routes::{
 	health::get_health,
 	metrics::get_metrics,
 	push::push,
+	readiness::get_readiness,
 	sheets::get_sheets,
 	signals::signals,
 	tab_metadata::post_now_playing,
@@ -32,14 +38,31 @@ use tower_http::{add_extension::AddExtensionLayer, limit::RequestBodyLimitLayer,
 async fn handle_tower_error(error: BoxError) -> FileHostError {
 	if error.is::<tower::timeout::error::Elapsed>() {
 		tracing::warn!("Request timeout: {}", error);
+		refusals::record_http("timeout");
 		FileHostError::RequestTimeout
 	} else if error.is::<tower::load_shed::error::Overloaded>() {
 		tracing::warn!("Service overloaded: {}", error);
+		refusals::record_http("load_shed");
 		FileHostError::ServiceOverloaded
 	} else {
 		tracing::error!("Unhandled tower error: {}", error);
 		FileHostError::TowerError(error)
 	}
+}
+
+/// `RequestBodyLimitLayer` answers an over-limit request directly — a `413`
+/// built inside the layer itself, never routed through `handle_tower_error`
+/// (see #223/F3). This wraps it from the outside instead, watching for that
+/// status on the way back out. Placed as the first layer inside
+/// `ServiceBuilder`'s chain so it sees everything `RequestBodyLimitLayer`
+/// (and everything beneath it) produces.
+async fn track_body_limit_refusals(req: AxumRequest, next: Next) -> Response {
+	let response = next.run(req).await;
+	if response.status() == StatusCode::PAYLOAD_TOO_LARGE {
+		tracing::warn!("Request body exceeded the configured limit");
+		refusals::record_http("body_limit");
+	}
+	response
 }
 
 #[tokio::main]
@@ -56,7 +79,18 @@ async fn main() -> Result<()> {
 	// `counter!`/`histogram!` call anywhere in this process, direct or via
 	// `crate::metrics::instruments`, writes through this recorder from here
 	// on; the handle below is what turns its state into a scrape payload.
-	let metrics_handle = some_metrics::install()?;
+	//
+	// `install_with` rather than `install`: the request-duration histogram
+	// (#213/F2) needs a bucket above `TASK_TIMEOUT_MS`'s 15s, and the
+	// exporter's default buckets top out at 10s — see
+	// `metrics::http::HTTP_DURATION_BUCKETS`'s own doc comment.
+	let metrics_builder = some_metrics::PrometheusBuilder::new().set_buckets_for_metric(some_metrics::Matcher::Full(HTTP_DURATION_METRIC.to_string()), HTTP_DURATION_BUCKETS)?;
+	let metrics_handle = some_metrics::install_with(metrics_builder)?;
+
+	// #213 (F4): which build the dashboard is describing, stamped once at
+	// startup so a restart shows as a discontinuity rather than an inference
+	// from a gap in an unrelated series.
+	file_host::metrics::build_info::record();
 
 	let config = Arc::new(config);
 	let connection_options = SqliteConnectOptions::from_str(&config.database_url)?
@@ -94,9 +128,19 @@ async fn main() -> Result<()> {
 	let app = Router::new()
 		.nest(API_V1_BASE_PATH, versioned_routes)
 		.merge(get_health())
+		.merge(get_readiness())
 		.merge(get_metrics(metrics_handle))
 		.merge(app_state.realtime.ws.clone().router())
 		.with_state(app_state.clone());
+
+	// #213 (F2): applied to the fully merged router so `MatchedPath` covers
+	// `/health`, `/ready`, `/metrics` and `/ws` alongside the versioned
+	// surface, not just `/api/v1/*`. `.layer(...)` only runs for requests
+	// axum's router actually matched; `.fallback(unmatched)` is the
+	// complementary path for everything else, recorded with a fixed
+	// `route="unmatched"` label so an unbounded set of garbage paths can
+	// never grow this metric's cardinality.
+	let app = app.layer(from_fn(track_http_metrics)).fallback(unmatched);
 
 	let app = app.layer(
 		ServiceBuilder::new()
@@ -108,6 +152,15 @@ async fn main() -> Result<()> {
 			.layer(LoadShedLayer::new())
 			.layer(AddExtensionLayer::new(config.clone())),
 	);
+
+	// #223 (F3): outermost, so it wraps `RequestBodyLimitLayer` above (and
+	// everything else) from the outside — see `track_body_limit_refusals`'s
+	// own doc comment for why that layer's own rejection can't be caught via
+	// `handle_tower_error`. `axum::middleware::from_fn` doesn't compose
+	// cleanly with `HandleErrorLayer` from inside the same `ServiceBuilder`
+	// chain (ambiguous `Service` inference), hence applying it as a separate
+	// `Router::layer` call rather than folding it into the chain above.
+	let app = app.layer(from_fn(track_body_limit_refusals));
 
 	// Only starts when the deployment asked for it *and* has a usable VAPID
 	// identity — `AppState::build` has already refused to boot if those two

--- a/apps/servers/file_host/src/metrics.rs
+++ b/apps/servers/file_host/src/metrics.rs
@@ -1,7 +1,13 @@
 #[allow(dead_code)]
+pub mod build_info;
+#[allow(dead_code)]
+pub mod http;
+#[allow(dead_code)]
 pub mod instruments;
 #[allow(dead_code)]
 pub mod observability;
+#[allow(dead_code)]
+pub mod refusals;
 
 #[allow(unused_imports)]
 pub use observability::{ObservabilityError, OtelGuard};

--- a/apps/servers/file_host/src/metrics/build_info.rs
+++ b/apps/servers/file_host/src/metrics/build_info.rs
@@ -1,0 +1,57 @@
+//! `service_info` and `process_start_time_seconds` — see #213 (F4).
+//!
+//! The build identity that makes every other panel trustworthy: when a
+//! panel goes red, "how long has it been like that" and "is this the build
+//! I think it is" are the first two questions, and neither is answerable
+//! from `env!("CARGO_PKG_VERSION")` alone — every crate in this workspace
+//! pins `version = "0.0.0"` (`Cargo.toml`'s `[workspace.package]`), so that
+//! string has never changed and never will. `GIT_SHA` (stamped by
+//! `build.rs`) is the identifier that actually distinguishes one deployed
+//! binary from the next.
+
+use metrics::gauge;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const SERVICE: &str = "file_host";
+pub const GIT_SHA: &str = env!("GIT_SHA");
+pub const GIT_DIRTY: &str = env!("GIT_DIRTY");
+pub const BUILT_AT: &str = env!("BUILD_TIMESTAMP");
+pub const RUSTC_VERSION: &str = env!("RUSTC_VERSION");
+
+/// `git_sha`, with a `-dirty` suffix when appropriate.
+///
+/// Set when `build.rs` ran against a working tree that had uncommitted
+/// changes — the same convention `git describe --dirty` uses, so it reads
+/// the same way in a log line as on the dashboard.
+#[must_use]
+pub fn git_sha_with_dirty_marker() -> String {
+	if GIT_DIRTY == "dirty" {
+		GIT_SHA.to_string() + "-dirty"
+	} else {
+		GIT_SHA.to_string()
+	}
+}
+
+/// Call once at startup, after `some_metrics::install_with` — mirrors that
+/// function's own one-call-per-process contract.
+///
+/// Emits `service_info{service,version,git_sha,built_at,rust}` fixed at `1`
+/// (the conventional "info gauge" shape: the interesting data lives in the
+/// labels, not the value) and `process_start_time_seconds` set once to the
+/// startup instant, so uptime is `time() - process_start_time_seconds` and a
+/// restart is a visible discontinuity rather than an inference from a gap in
+/// an unrelated series.
+pub fn record() {
+	gauge!(
+		"service_info",
+		"service" => SERVICE,
+		"version" => env!("CARGO_PKG_VERSION"),
+		"git_sha" => git_sha_with_dirty_marker(),
+		"built_at" => BUILT_AT,
+		"rust" => RUSTC_VERSION,
+	)
+	.set(1.0);
+
+	let start = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs_f64()).unwrap_or(0.0);
+	gauge!("process_start_time_seconds").set(start);
+}

--- a/apps/servers/file_host/src/metrics/http.rs
+++ b/apps/servers/file_host/src/metrics/http.rs
@@ -1,0 +1,164 @@
+//! `http_requests_total{route,method,status}` and a duration histogram on
+//! the same dimensions. See #213 (F2).
+//!
+//! `route` is always the axum-matched path *pattern* (`/api/v1/foo/:id`),
+//! never the raw request path — that keeps the label's cardinality bounded
+//! to the checked route inventory (`routes::inventory::ROUTES`) rather than
+//! unbounded by whatever a client happened to request. A path nothing
+//! matched labels as `"unmatched"`; see [`unmatched`], the router's
+//! `.fallback(...)` handler that is the only other place this metric is
+//! recorded from.
+
+use axum::{
+	extract::{MatchedPath, Request},
+	http::StatusCode,
+	middleware::Next,
+	response::{IntoResponse, Response},
+};
+use metrics::{counter, histogram};
+use std::time::Instant;
+
+/// `PrometheusBuilder::set_buckets_for_metric`'s target for [`HTTP_DURATION_METRIC`].
+///
+/// See `main.rs`'s `some_metrics::install_with` call, which is where this
+/// actually takes effect. The exporter's default buckets top out at 10s;
+/// `TASK_TIMEOUT_MS` (`config.rs`) defaults to 15,000ms, so a request that
+/// times out needs a bucket above that or it falls off the end of the
+/// histogram into `+Inf` and p99 becomes unrepresentable for exactly the
+/// requests it matters most to see.
+pub const HTTP_DURATION_BUCKETS: &[f64] = &[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 15.0, 30.0];
+
+/// Kept as a constant, not a literal at each call site, so the bucket
+/// override in `main.rs` and the `histogram!` call below can't drift apart.
+pub const HTTP_DURATION_METRIC: &str = "http_request_duration_seconds";
+
+/// `GET /metrics` never counts itself — a scraper hitting its own scrape
+/// target every interval would otherwise be the single busiest "route" on
+/// every deployment, telling you about Prometheus rather than about the
+/// service.
+const EXCLUDED_ROUTE: &str = "/metrics";
+
+/// The router's outermost `.layer(middleware::from_fn(...))`. Only runs for
+/// requests axum's router actually matched — see [`unmatched`] for the
+/// complementary fallback path.
+pub async fn track_http_metrics(req: Request, next: Next) -> Response {
+	let route = req.extensions().get::<MatchedPath>().map(|p| p.as_str().to_owned());
+
+	match route {
+		Some(route) if route == EXCLUDED_ROUTE => next.run(req).await,
+		Some(route) => record_and_run(req, next, route).await,
+		// A `.layer()` middleware only runs once routing has already
+		// resolved (unmatched paths go through `.fallback(unmatched)`
+		// instead), so this should be unreachable — falling through to
+		// "unmatched" rather than panicking keeps this middleware
+		// infallible regardless.
+		None => record_and_run(req, next, "unmatched".to_string()).await,
+	}
+}
+
+async fn record_and_run(req: Request, next: Next, route: String) -> Response {
+	let method = req.method().to_string();
+	let start = Instant::now();
+
+	let response = next.run(req).await;
+
+	let status = response.status().as_u16().to_string();
+	let elapsed = start.elapsed().as_secs_f64();
+
+	counter!("http_requests_total", "route" => route.clone(), "method" => method.clone(), "status" => status).increment(1);
+	histogram!(HTTP_DURATION_METRIC, "route" => route, "method" => method).record(elapsed);
+
+	response
+}
+
+/// The router's `.fallback(...)`.
+///
+/// The only other place `http_requests_total` is recorded from — every
+/// request no route matched lands here, always labelled `route="unmatched"`
+/// regardless of the path actually requested, so a client scanning random
+/// paths cannot grow this metric's cardinality.
+///
+/// `async` despite no `.await`: `Router::fallback`'s `Handler` bound
+/// requires it — axum handlers are async by trait, not by choice here.
+#[allow(clippy::unused_async)]
+pub async fn unmatched(req: Request) -> impl IntoResponse {
+	let method = req.method().to_string();
+	counter!("http_requests_total", "route" => "unmatched", "method" => method, "status" => "404").increment(1);
+	(StatusCode::NOT_FOUND, "not found")
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::routes::inventory::{RouteDescriptor, ROUTES};
+	use axum::{
+		body::Body,
+		http::Request as HttpRequest,
+		routing::{delete, get, patch, post, put, MethodRouter},
+		Router,
+	};
+	use std::collections::BTreeSet;
+	use tower::ServiceExt;
+
+	async fn stub() -> &'static str {
+		"ok"
+	}
+
+	fn method_router(method: &str) -> MethodRouter {
+		match method {
+			"GET" => get(stub),
+			"POST" => post(stub),
+			"PUT" => put(stub),
+			"PATCH" => patch(stub),
+			"DELETE" => delete(stub),
+			other => panic!("unhandled method in ROUTES: {other}"),
+		}
+	}
+
+	/// #222's acceptance criteria: "the `route` label values are a subset of
+	/// the inventory". A bare router (no `AppState`, no handlers with real
+	/// bodies — `routes/inventory.rs`'s own tests avoid needing a fully built
+	/// `AppState` for exactly this reason) carrying every `ROUTES` path under
+	/// the same middleware this app installs, then asserting the
+	/// `MatchedPath` this middleware would label with is *exactly*
+	/// `route.full_path()` for every declared route. Catches, at compile+test
+	/// time rather than in a scrape years from now, a route whose declared
+	/// path syntax doesn't actually match what axum resolves (e.g. a stray
+	/// `{name}` where axum expects `:name`, or a `/api/v1` nesting mismatch).
+	#[tokio::test]
+	async fn matched_path_equals_route_inventory_full_path() {
+		let versioned: Router = ROUTES.iter().filter(|r| r.versioned).fold(Router::new(), |r, route| r.route(route.path, method_router(route.method)));
+		let unversioned: Router = ROUTES.iter().filter(|r| !r.versioned).fold(Router::new(), |r, route| r.route(route.path, method_router(route.method)));
+		let app = Router::new().nest(crate::API_V1_BASE_PATH, versioned).merge(unversioned).layer(axum::middleware::from_fn(record_matched_path));
+
+		let inventory_paths: BTreeSet<String> = ROUTES.iter().map(RouteDescriptor::full_path).collect();
+
+		for route in ROUTES {
+			// `/ws` upgrades the connection rather than resolving as a plain
+			// handler call; a bare GET against it is expected to fail the
+			// upgrade, not the routing, so it is exempt from being driven
+			// through `oneshot` here.
+			if route.path == "/ws" {
+				continue;
+			}
+			let full_path = route.full_path();
+			let request = HttpRequest::builder().method(route.method).uri(&full_path).body(Body::empty()).unwrap();
+			let response = app.clone().oneshot(request).await.unwrap();
+			let matched = response.headers().get("x-test-matched-path").map(|v| v.to_str().unwrap().to_owned());
+			assert_eq!(matched.as_deref(), Some(full_path.as_str()), "route {full_path} did not resolve to its own declared path");
+			assert!(inventory_paths.contains(&full_path));
+		}
+	}
+
+	// A middleware that reports the `MatchedPath` it saw back to the test
+	// via a response header, so the test above can assert on it without
+	// needing the real `metrics` facade recorder installed.
+	async fn record_matched_path(req: Request, next: Next) -> Response {
+		let matched = req.extensions().get::<MatchedPath>().map(|p| p.as_str().to_owned());
+		let mut response = next.run(req).await;
+		if let Some(matched) = matched {
+			response.headers_mut().insert("x-test-matched-path", matched.parse().unwrap());
+		}
+		response
+	}
+}

--- a/apps/servers/file_host/src/metrics/refusals.rs
+++ b/apps/servers/file_host/src/metrics/refusals.rs
@@ -1,0 +1,41 @@
+//! `refusals_total{stage,reason}` — see #213 (F3).
+//!
+//! This server declines work in several distinct ways, and refusal is fault
+//! condition #4 — **saturated** — the one that looks healthiest from every
+//! other angle: every request that *is* served stays fast, because the slow
+//! ones were never admitted. Before this, the only evidence was a `warn!`
+//! or `error!` line nobody was watching. These counters sit next to those
+//! log lines, not in place of them — the log says what happened, the
+//! metric says when to look.
+//!
+//! `stage` is `"http"` or `"ws"`. `reason` is one of:
+//!
+//!   http: `timeout`, `load_shed`, `body_limit`
+//!   ws:   `global_capacity`, `queue_full`, `permit_timeout`
+//!
+//! Two rows from #213's refusal table are deliberately not counted here:
+//!
+//! - **Rate limited** (`some-services/rate_limiter/token_bucket.rs`) — #215
+//!   owns instrumenting the limiter itself; this story counts what already
+//!   has a decision point to count, not what a different epic still has to
+//!   fix.
+//! - **Concurrency limit** (`tower::limit::ConcurrencyLimitLayer`) — in the
+//!   tower 0.4 this workspace pins, `ConcurrencyLimit::poll_ready` never
+//!   produces an error; it is pure backpressure (`Poll::Pending` on a
+//!   semaphore) with no discrete "refused" event to count. When sustained
+//!   concurrency pressure does turn into an actual refusal, that refusal
+//!   happens at a layer this module *does* count — `load_shed` if
+//!   `LoadShedLayer` sheds it, `timeout` if `TimeoutLayer` elapses first.
+//!   Inventing a synthetic "queued" counter here would mean fabricating a
+//!   signal tower itself doesn't produce, which is exactly what this story
+//!   (and #223's "observe first" non-goal) argues against.
+
+use metrics::counter;
+
+pub fn record_http(reason: &'static str) {
+	counter!("refusals_total", "stage" => "http", "reason" => reason).increment(1);
+}
+
+pub fn record_ws(reason: &'static str) {
+	counter!("refusals_total", "stage" => "ws", "reason" => reason).increment(1);
+}

--- a/apps/servers/file_host/src/routes/inventory.rs
+++ b/apps/servers/file_host/src/routes/inventory.rs
@@ -82,6 +82,12 @@ pub const ROUTES: &[RouteDescriptor] = &[
 	},
 	RouteDescriptor {
 		method: "GET",
+		path: "/ready",
+		versioned: false,
+		module: "readiness",
+	},
+	RouteDescriptor {
+		method: "GET",
 		path: "/ws",
 		versioned: false,
 		module: "websocket",
@@ -458,6 +464,7 @@ mod tests {
 	/// half of that mistake it can see.
 	const SOURCES: &[(&str, &str, bool)] = &[
 		("health", include_str!("health.rs"), false),
+		("readiness", include_str!("readiness.rs"), false),
 		("websocket", include_str!("../websocket.rs"), false),
 		("sheets", include_str!("sheets.rs"), true),
 		("gdrive", include_str!("gdrive.rs"), true),

--- a/apps/servers/file_host/src/routes/mod.rs
+++ b/apps/servers/file_host/src/routes/mod.rs
@@ -7,6 +7,7 @@ pub mod health;
 pub mod inventory;
 pub mod metrics;
 pub mod push;
+pub mod readiness;
 pub mod sheets;
 pub mod signals;
 pub mod tab_metadata;

--- a/apps/servers/file_host/src/routes/readiness.rs
+++ b/apps/servers/file_host/src/routes/readiness.rs
@@ -1,0 +1,15 @@
+//! `GET /ready` — see `handlers::readiness`. Unversioned and un-CORS'd like
+//! `/health` and `/metrics`: load balancers and `depends_on: condition:
+//! service_healthy` read this, not a browser.
+
+use crate::handlers::readiness as routes;
+use crate::AppState;
+use axum::{extract::FromRef, routing::get, Router};
+
+pub fn get_readiness<S>() -> Router<S>
+where
+	S: Clone + Send + Sync + 'static,
+	AppState: FromRef<S>,
+{
+	Router::new().route("/ready", get(routes::readiness))
+}

--- a/apps/servers/file_host/src/websocket.rs
+++ b/apps/servers/file_host/src/websocket.rs
@@ -119,6 +119,7 @@ async fn websocket_handler(ws: WebSocketUpgrade, State(state): State<AppState>, 
 
 	if !state.core.connection_guard.try_acquire_permit_hint() {
 		warn!("Global limit exceeded — rejecting early");
+		crate::metrics::refusals::record_ws("global_capacity");
 		return (StatusCode::SERVICE_UNAVAILABLE, "Too many connections").into_response();
 	}
 
@@ -127,15 +128,21 @@ async fn websocket_handler(ws: WebSocketUpgrade, State(state): State<AppState>, 
 		Ok(Ok(permit)) => ws.on_upgrade(move |socket| handle_socket(socket, state, headers, addr, permit, cancel_token)),
 		Ok(Err(err)) => {
 			use AcquireErrorKind::*;
-			let reason = match err.kind {
-				QueueFull => "Too many pending connections for this client",
-				GlobalLimit => "Server is at capacity",
+			let (reason, metric_reason) = match err.kind {
+				QueueFull => ("Too many pending connections for this client", "queue_full"),
+				// A second, near-unreachable path to the same fast-path
+				// hint's conclusion — it only fires if the global semaphore
+				// is closed, which nothing in this codebase does today —
+				// so it shares that reason rather than inventing a fourth.
+				GlobalLimit => ("Server is at capacity", "global_capacity"),
 			};
 			error!("Rejecting WS for {client_id}: {reason}");
+			crate::metrics::refusals::record_ws(metric_reason);
 			(StatusCode::SERVICE_UNAVAILABLE, reason).into_response()
 		}
 		Err(_timeout_elapsed) => {
 			error!("Timeout waiting for permit for {client_id}");
+			crate::metrics::refusals::record_ws("permit_timeout");
 			(StatusCode::REQUEST_TIMEOUT, "Connection acquisition timed out").into_response()
 		}
 	}

--- a/crates/some-metrics/src/lib.rs
+++ b/crates/some-metrics/src/lib.rs
@@ -9,8 +9,14 @@
 //! [issue-139]: https://github.com/paulgsc/server/issues/139
 
 use axum::{extract::Extension, routing::get, Router};
-use metrics_exporter_prometheus::{BuildError, PrometheusBuilder, PrometheusHandle};
+use metrics_exporter_prometheus::{BuildError, PrometheusHandle};
 use std::net::SocketAddr;
+
+// Re-exported so a caller can configure the builder (histogram buckets,
+// quantiles, …) before installing it, without taking its own direct
+// dependency on `metrics-exporter-prometheus` — this crate already owns
+// that version pin. See [`install_with`].
+pub use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
 
 #[derive(Debug, thiserror::Error)]
 pub enum MetricsError {
@@ -36,7 +42,8 @@ impl MetricsHandle {
 	}
 }
 
-/// Install the global `metrics` recorder, backed by a Prometheus exporter.
+/// Install the global `metrics` recorder, backed by a Prometheus exporter,
+/// with the exporter's default configuration.
 ///
 /// Call this exactly once per process, before anything records a
 /// measurement. The returned handle is what turns the recorder's state into
@@ -47,7 +54,26 @@ impl MetricsHandle {
 /// Returns [`MetricsError::Install`] if a global recorder is already
 /// installed — this must be called at most once per process.
 pub fn install() -> Result<MetricsHandle, MetricsError> {
-	let handle = PrometheusBuilder::new().install_recorder()?;
+	install_with(PrometheusBuilder::new())
+}
+
+/// Install the global `metrics` recorder from a caller-configured builder —
+/// for a service that needs its own histogram buckets (default buckets top
+/// out at 10s; a request-duration histogram sitting behind a 15s timeout
+/// needs a bucket above it, or timeouts fall off the end of the histogram)
+/// or quantiles. `PrometheusBuilder` and [`Matcher`] are re-exported from
+/// this crate so a caller never needs its own direct
+/// `metrics-exporter-prometheus` dependency.
+///
+/// Otherwise identical to [`install`] — same one-call-per-process rule, same
+/// use of the returned handle.
+///
+/// # Errors
+///
+/// Returns [`MetricsError::Install`] if a global recorder is already
+/// installed, or if `builder` was misconfigured (e.g. empty buckets).
+pub fn install_with(builder: PrometheusBuilder) -> Result<MetricsHandle, MetricsError> {
+	let handle = builder.install_recorder()?;
 	Ok(MetricsHandle(handle))
 }
 

--- a/crates/some-transport/src/nats/transport.rs
+++ b/crates/some-transport/src/nats/transport.rs
@@ -132,10 +132,25 @@ where
 	/// wasted work. The async_nats client will automatically reconnect
 	/// when the network recovers.
 	fn check_connection(&self) -> Result<()> {
-		if self.client.connection_state() != async_nats::connection::State::Connected {
+		if !self.is_connected() {
 			return Err(TransportError::NatsError("Connection not established".to_string()));
 		}
 		Ok(())
+	}
+
+	/// A non-blocking read of the client's last-known connection state.
+	///
+	/// Not a round-trip — `async_nats::Client` maintains this itself and
+	/// updates it as its background reconnect loop observes the socket, so
+	/// this never blocks or can hang. That is a deliberate readiness-probe
+	/// property (see #221): a check that can hang is worse than one that
+	/// answers instantly with slightly stale information, and asking this
+	/// client for round-trip proof of liveness would require a `.flush()`
+	/// waiting on the server, which is not bounded by anything shorter than
+	/// its own retry backoff.
+	#[must_use]
+	pub fn is_connected(&self) -> bool {
+		self.client.connection_state() == async_nats::connection::State::Connected
 	}
 
 	/// Generates a subject name for a connection-specific channel.

--- a/docs/fault-conditions.md
+++ b/docs/fault-conditions.md
@@ -1,0 +1,74 @@
+# Fault conditions (#213)
+
+## The question, and why it needed a strict definition
+
+"Is my server in a fault state" doesn't compile as a dashboard panel until
+it's broken into predicates — each one either true or not, each separately
+observable and separately falsifiable. Before this epic, the only thing
+claiming to answer this question was `/health`, and it answered with a
+string literal that consulted nothing. A service in any of the six states
+below looked identical to a healthy one.
+
+**Resource pressure is not a fault state.** High CPU, high RSS, and a
+growing disk footprint are *sizing* facts, not fault conditions — a service
+at 90% of its memory limit and serving every request correctly is not
+faulted, it is expensive. The only overlap with sizing is condition #4
+below, and only where saturation is *observed as refused work*, never
+inferred from a resource ceiling.
+
+## The six conditions
+
+### 1. Unreachable {#unreachable}
+
+`up{job=...} == 0`. The process is gone or the scrape path broke.
+Distinguishable from every other row *only* because the others require a
+live scrape to even be false — this is the one that fires when nothing else
+can be evaluated at all.
+
+### 2. Dependency down {#dependency-down}
+
+`/ready` non-200, per-dependency gauge. SQLite pool exhausted, NATS
+disconnected, Redis unreachable — before #221 (F1), all three were invisible
+until a request happened to fail. `handlers::readiness` checks each with a
+bounded timeout and exports `dependency_up{dependency="sqlite"|"nats"|"redis"}`.
+
+### 3. Rejecting {#rejecting}
+
+Elevated 5xx rate. `main.rs`'s tower stack already sheds and times out
+(`LoadShedLayer`, `TimeoutLayer`) — before #222 (F2), both outcomes were
+indistinguishable from success in every aggregate that existed.
+`http_requests_total{status=~"5.."}` is what makes them visible.
+
+### 4. Saturated {#saturated}
+
+Admission-control refusals: load shedding, WS `ConnectionGuard` 503s,
+permit-acquire timeouts. This is the fault state that *looks* healthiest
+from every other angle — every request that *is* served stays fast, because
+the slow ones were never admitted. `refusals_total{stage,reason}` (#223/F3)
+is the only place this was ever counted.
+
+### 5. Stalled {#stalled}
+
+Age of the last successful background pass exceeds 3× its interval. The
+`nudge` waker (see the [PUSH] epic, #236) is designed so a quiet day and a
+dead loop produce byte-identical output: nothing. A last-success timestamp
+gauge turns "nothing happened" into a comparison against a known interval
+instead of a silence nobody can distinguish from correctness.
+
+### 6. Blind {#blind}
+
+A series the dashboard depends on has no data. Established by the [GLANCE]
+epic (#212, `docs/dashboard-honesty.md`). Listed here because being unable
+to evaluate conditions #1–#5 is itself a fault state — and, before #212, was
+the one this repo was actually in. A monitoring system that cannot
+distinguish "nothing is wrong" from "I cannot tell" is not a monitoring
+system.
+
+## Where this is enforced
+
+The HEALTH row at the top of `infra/grafana/dashboards/dashboard.jsonnet`
+(#225/F5) renders all six as one row of stat panels: UP (#1), DEPS (#2),
+ERRORS (#3), REFUSALS (#4), LOOPS (#5), SIGNAL (#6 — red the instant any of
+the other five goes grey, so "five greens" and "five greys" can never be
+mistaken for each other at a glance). Each panel links back to its
+condition's anchor on this page.

--- a/infra/docker/Dockerfile.server
+++ b/infra/docker/Dockerfile.server
@@ -50,6 +50,17 @@ RUN cargo chef prepare --recipe-path recipe.json --bin file_host
 #   3. Build only the target binary
 FROM chef AS builder
 
+# Populated by CI via --build-arg (see .github/actions/docker-build). Not
+# just OCI LABEL metadata (below) — apps/servers/file_host/build.rs reads
+# these same names to stamp the `service_info` metric the binary itself
+# reports (#213/F4), since `.git` isn't in this build context for it to
+# derive them from directly. Defaulted so a local `docker build` with no
+# --build-arg still produces a working, honestly-"unknown"-labelled image.
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+ENV VCS_REF=${VCS_REF}
+ENV BUILD_DATE=${BUILD_DATE}
+
 # Step 1: build dependency layer
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
@@ -126,7 +137,9 @@ EXPOSE 3000
 ENTRYPOINT ["/usr/local/bin/file_host"]
 
 # ── Metadata ──────────────────────────────────────────────────────────────
-# Populated by CI at build time
+# Populated by CI at build time. ARGs don't cross the FROM boundary from the
+# builder stage above, so VCS_REF/BUILD_DATE are declared again here — same
+# --build-arg values, now labelling the image rather than feeding build.rs.
 ARG APP_NAME=unknown
 ARG BUILD_VERSION=unknown
 ARG BUILD_DATE=unknown

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -14,12 +14,14 @@ Every panel's query is checked against what this workspace actually emits
 by `scripts/check_metric_contract.py` (#217) — see
 `docs/dashboard-honesty.md` for the rule that check exists to enforce, and
 why "no data" and "healthy" have to be visually different states.
+`docs/fault-conditions.md` (#213) is the companion definition for the six
+conditions `dashboard.jsonnet`'s HEALTH row renders a verdict on.
 
 ## Active dashboards
 
 | Dashboard | Answers | Backed by | Owning epic |
 |---|---|---|---|
-| `dashboard.jsonnet` | Is file_host up, and is its one instrumented operation path within latency budget? | `probe_success`/`probe_duration_seconds` (blackbox-exporter), `operation_duration_seconds` (file_host, `metrics` facade) | #212 (G2/G3) |
+| `dashboard.jsonnet` | Is file_host in a fault state (six conditions, `docs/fault-conditions.md`), and is its instrumented traffic within latency budget? | `up`, `dependency_up`, `http_requests_total`/`http_request_duration_seconds`, `refusals_total`, `service_info`, `process_start_time_seconds` (file_host, `metrics` facade), `probe_success`/`probe_duration_seconds` (blackbox-exporter), `operation_duration_seconds` | #212 (G2/G3), #213 (F1–F5) |
 | `sys-dashboard.jsonnet` | Is the host itself healthy — CPU, memory, disk, network? | `node_*` (node_exporter) | #212 (G2/G3) |
 | `processor.jsonnet` ("WHO DUNNIT") | If the host hangs, which process/container did it? | `namedprocess_*` (process-exporter), `container_*` (cadvisor), `node_*`, `up`, `ALERTS` | #212 (G2/G3) |
 | `cache-dashboard.jsonnet` | Is `some-cache`'s hit rate healthy, and is the dedup guard absorbing thundering herds? | `cache_hits_total`, `cache_misses_total`, `cache_fetch_duration_seconds`, `cache_dedup_waiters_total` (some-cache, `metrics` facade, namespace-labeled) | #212 (G2/G3/G4 — rewritten from a 14-fake-name version) |
@@ -40,7 +42,7 @@ reason: a parked dashboard's query isn't a claim Grafana is currently making.
 
 | Dashboard | Assumes | Returns via |
 |---|---|---|
-| `rate-limit.jsonnet` | `http_requests_total*` — no axum-prometheus layer or manual counter emits this | the [ABUSE] epic, once it defines a real request counter |
+| `rate-limit.jsonnet` | `http_requests_total{status="429"}` — #213 (F2) landed the `http_requests_total{route,method,status}` metric this dashboard queries, and the rate limiter does answer `429` (`apps/servers/file_host/src/rate_limiter/token_bucket.rs`), so the metric this dashboard assumes now exists. Still parked: the panels themselves need the [ABUSE] epic's own pass — the queries were written against a different (client-IP-labelled) assumption than what F2 actually shipped, and `http_requests_total_by_client` specifically is still unbounded cardinality per F2's own non-goals | the [ABUSE] epic |
 | `ws-dashboard.jsonnet` | `ws_connection_*`/`ws_client_*` — registered in `apps/servers/file_host/src/websocket/connection/instrument.rs` via the raw `prometheus` crate, but every recording macro has zero call sites, so nothing ever dereferences the `lazy_static` | the [CLIENTS] epic, once those call sites exist (or the metrics move to the `metrics` facade) |
 
 ## Removed

--- a/infra/grafana/dashboards/dashboard.jsonnet
+++ b/infra/grafana/dashboards/dashboard.jsonnet
@@ -1,6 +1,7 @@
 local panels = import 'lib/panels.libsonnet';
 local utils = import 'lib/utils.libsonnet';
 local panelDefaults = import 'lib/panel-defaults.libsonnet';
+local health = import 'lib/health-panels.libsonnet';
 
 local dashboard = {
   annotations: {
@@ -16,6 +17,22 @@ local dashboard = {
         name: 'Annotations & Alerts',
         type: 'dashboard',
       },
+      {
+        // #213/F4: "add a dashboard annotation on restarts, so a red panel
+        // can be attributed to a deploy at a glance." `process_start_time_seconds`
+        // (build_info::record) is set once at startup and holds constant
+        // for the process's life, so `changes()` — which counts any change
+        // within the window, not just increases — fires exactly once per
+        // restart, the instant it jumps to the new start time.
+        datasource: { type: 'prometheus', uid: 'prometheus' },
+        enable: true,
+        expr: 'changes(process_start_time_seconds[$__interval]) > 0',
+        iconColor: 'purple',
+        name: 'Restarts',
+        step: '60s',
+        titleFormat: 'file_host restarted',
+        type: 'dashboard',
+      },
     ],
   },
   editable: true,
@@ -25,31 +42,50 @@ local dashboard = {
   links: [],
   liveNow: false,
   panels: panelDefaults.hardenAll([
-    // =============== ROW 1: UPTIME SLA (TOP PRIORITY) ===============
-    panels.uptimeOverallStatus { gridPos: utils.gridPos(0, 0, 6, 4) },
-    panels.uptimeSLA30d { gridPos: utils.gridPos(6, 0, 6, 4) },
-    panels.tcpConnectivity { gridPos: utils.gridPos(12, 0, 6, 4) },
-    panels.httpWebSocketProbe { gridPos: utils.gridPos(18, 0, 6, 4) },
+    // =============== HEALTH (#213/#225) ===============
+    // Six conditions, six panels, ordered by diagnostic precedence — UP
+    // before DEPS before the rest, so the leftmost red is the one to
+    // investigate. See docs/fault-conditions.md; each panel links to its
+    // own condition there.
+    health.up { gridPos: utils.gridPos(0, 0, 4, 4) },
+    health.deps { gridPos: utils.gridPos(4, 0, 4, 4) },
+    health.errors { gridPos: utils.gridPos(8, 0, 4, 4) },
+    health.refusals { gridPos: utils.gridPos(12, 0, 4, 4) },
+    health.loops { gridPos: utils.gridPos(16, 0, 4, 4) },
+    health.signal { gridPos: utils.gridPos(20, 0, 4, 4) },
+
+    // Which build this is, and how long it's been running — see
+    // health-panels.libsonnet's own comment on `buildInfo`/`uptime`.
+    health.buildInfo { gridPos: utils.gridPos(0, 4, 18, 2) },
+    health.uptime { gridPos: utils.gridPos(18, 4, 6, 2) },
+
+    health.requestRateByOutcome { gridPos: utils.gridPos(0, 6, 24, 6) },
+    health.httpLatencyByRoute { gridPos: utils.gridPos(0, 12, 24, 6) },
+
+    // =============== ROW 1: UPTIME SLA ===============
+    panels.uptimeOverallStatus { gridPos: utils.gridPos(0, 18, 6, 4) },
+    panels.uptimeSLA30d { gridPos: utils.gridPos(6, 18, 6, 4) },
+    panels.tcpConnectivity { gridPos: utils.gridPos(12, 18, 6, 4) },
+    panels.httpWebSocketProbe { gridPos: utils.gridPos(18, 18, 6, 4) },
 
     // =============== ROW 2: UPTIME TRENDS & DIAGNOSTICS ===============
-    panels.uptimeTrend7d { gridPos: utils.gridPos(0, 4, 12, 8) },
-    panels.probeDiagnostics { gridPos: utils.gridPos(12, 4, 12, 8) },
+    panels.uptimeTrend7d { gridPos: utils.gridPos(0, 22, 12, 8) },
+    panels.probeDiagnostics { gridPos: utils.gridPos(12, 22, 12, 8) },
 
     // =============== ROW 3: APPLICATION METRICS ===============
-    panels.operationDuration { gridPos: utils.gridPos(0, 12, 12, 8) },
-
-    // #219: "no data everywhere" on this row should read as "file_host is
-    // not being scraped", not as "operations dropped to zero".
-    panelDefaults.livenessPanel('file_host liveness', ['file_host'], 15, utils.gridPos(12, 12, 12, 8)),
+    // The standalone liveness stat this row used to carry (#212/G3) is
+    // superseded by the HEALTH row's UP panel above, which is the same
+    // `up{job="file_host"}` query — no need for both.
+    panels.operationDuration { gridPos: utils.gridPos(0, 30, 24, 8) },
   ]),
-  refresh: '10s',
+  refresh: '5s',
   schemaVersion: 38,
-  tags: ['rust', 'axum', 'prometheus', 'sla'],
+  tags: ['rust', 'axum', 'prometheus', 'sla', 'health'],
   templating: { list: [] },
   time: { from: 'now-1h', to: 'now' },
   timepicker: {},
   timezone: '',
-  title: '🚀 Service Uptime & Performance Dashboard',
+  title: '🩺 file_host Operational Dashboard',
   uid: 'file-host-dashboard',
   version: 1,
 };

--- a/infra/grafana/dashboards/lib/health-panels.libsonnet
+++ b/infra/grafana/dashboards/lib/health-panels.libsonnet
@@ -1,0 +1,256 @@
+// health-panels.libsonnet
+//
+// The HEALTH row — #213/#225 (F5). Six conditions, six stat panels, all
+// boring: green/red/grey and nothing else. See docs/fault-conditions.md for
+// the strict definition each panel renders a verdict on; each panel below
+// links back to its own condition's anchor there.
+local panelDefaults = import 'panel-defaults.libsonnet';
+
+local docsUrl = 'https://github.com/paulgsc/server/blob/main/docs/fault-conditions.md';
+
+// #236 ([PUSH] P4, a sibling epic) has not landed yet — nothing in this
+// workspace emits `nudge_waker_last_pass_timestamp_seconds`, which the
+// LOOPS/SIGNAL panels below query anyway: #219's rule is exactly built for
+// this, a query against an as-yet-unemitted metric renders grey (unknown),
+// never green, so the panel is honest on day one and starts reporting real
+// data the moment #236 lands with no dashboard change required.
+// scripts/check_metric_contract.py carries the matching EXEMPT_QUERIED
+// entry with this same reason. LOOPS' `900` threshold is 3x
+// `nudge_waker_seconds`' own default (config.rs) — #236's own task list
+// promises a `nudge_waker_interval_seconds` gauge so this can derive from
+// live configuration instead; until it lands, 3x the *default* interval is
+// the best static approximation available.
+
+local docLink(anchor) = [
+  {
+    title: 'What this means',
+    url: docsUrl + '#' + anchor,
+    targetBlank: true,
+  },
+];
+
+{
+  // UP — condition #1 (unreachable). Reuses panelDefaults.livenessPanel, the
+  // same 0/1/no-data convention used by every other dashboard's liveness row.
+  up: panelDefaults.livenessPanel('UP', ['file_host'], 900, {}) { links: docLink('unreachable') },
+
+  // DEPS — condition #2 (dependency down). `unit: '/3'` is Grafana's plain
+  // custom-suffix mechanism — a raw value of 3 renders as "3/3".
+  deps: {
+    title: 'DEPS',
+    type: 'stat',
+    id: 901,
+    links: docLink('dependency-down'),
+    targets: [{ expr: 'sum(dependency_up)', instant: true, refId: 'A' }],
+    fieldConfig: {
+      defaults: {
+        unit: '/3',
+        color: { mode: 'thresholds' },
+        thresholds: { mode: 'absolute', steps: [{ color: 'red', value: null }, { color: 'green', value: 3 }] },
+      },
+      overrides: [],
+    },
+    options: { colorMode: 'value', graphMode: 'none', justifyMode: 'center', orientation: 'horizontal', reduceOptions: { calcs: ['lastNotNull'], values: false }, textMode: 'value' },
+  },
+
+  // ERRORS — condition #3 (rejecting). Sustained non-zero 5xx rate is red;
+  // the 5m rate window is what makes "sustained" mean something rather than
+  // reddening on a single blip.
+  errors: {
+    title: 'ERRORS',
+    type: 'stat',
+    id: 902,
+    links: docLink('rejecting'),
+    targets: [{ expr: 'sum(rate(http_requests_total{status=~"5.."}[5m]))', instant: true, refId: 'A' }],
+    fieldConfig: {
+      defaults: {
+        unit: 'reqps',
+        decimals: 2,
+        color: { mode: 'thresholds' },
+        thresholds: { mode: 'absolute', steps: [{ color: 'green', value: null }, { color: 'red', value: 0.001 }] },
+      },
+      overrides: [],
+    },
+    options: { colorMode: 'value', graphMode: 'none', justifyMode: 'center', orientation: 'horizontal', reduceOptions: { calcs: ['lastNotNull'], values: false }, textMode: 'value' },
+  },
+
+  // REFUSALS — condition #4 (saturated). Same "sustained non-zero is red"
+  // shape as ERRORS, over every reason #223 counts (http and ws stages
+  // alike — this panel answers *whether*, not *which*; the request-rate
+  // timeseries below and refusals_total itself answer *which*).
+  refusals: {
+    title: 'REFUSALS',
+    type: 'stat',
+    id: 903,
+    links: docLink('saturated'),
+    targets: [{ expr: 'sum(rate(refusals_total[5m]))', instant: true, refId: 'A' }],
+    fieldConfig: {
+      defaults: {
+        unit: 'ops',
+        decimals: 2,
+        color: { mode: 'thresholds' },
+        thresholds: { mode: 'absolute', steps: [{ color: 'green', value: null }, { color: 'red', value: 0.001 }] },
+      },
+      overrides: [],
+    },
+    options: { colorMode: 'value', graphMode: 'none', justifyMode: 'center', orientation: 'horizontal', reduceOptions: { calcs: ['lastNotNull'], values: false }, textMode: 'value' },
+  },
+
+  // LOOPS — condition #5 (stalled). See `waker_last_pass`/`stalledAfterSeconds`
+  // above for why this queries a metric #236 hasn't landed yet, and why the
+  // threshold is a static stand-in for that story's own configured-interval
+  // gauge.
+  loops: {
+    title: 'LOOPS',
+    type: 'stat',
+    id: 904,
+    links: docLink('stalled'),
+    // #217's contract check (scripts/check_metric_contract.py) reads
+    // `expr:` literally out of this file, the same way it reads every other
+    // panel library — jsonnet's `%` string interpolation would hide the
+    // literal metric name from it, so this is written out directly rather
+    // than built from `waker_last_pass`/`stalledAfterSeconds` above (which
+    // exist to document *why*, not to be interpolated from).
+    targets: [{ expr: '(time() - nudge_waker_last_pass_timestamp_seconds) > bool 900', instant: true, refId: 'A' }],
+    fieldConfig: {
+      defaults: {
+        unit: 'none',
+        mappings: [{ type: 'value', options: { '0': { text: 'ok', color: 'green' }, '1': { text: 'STALLED', color: 'red' } } }],
+        color: { mode: 'thresholds' },
+        thresholds: { mode: 'absolute', steps: [{ color: panelDefaults.unknownColor, value: null }] },
+      },
+      overrides: [],
+    },
+    options: { colorMode: 'value', graphMode: 'none', justifyMode: 'center', orientation: 'horizontal', reduceOptions: { calcs: ['lastNotNull'], values: false }, textMode: 'value' },
+  },
+
+  // SIGNAL — condition #6 (blind). Red the instant *any* of the five panels
+  // above is grey, so "five greens" and "five greys" are never mistaken for
+  // each other at a glance. `sum(absent(x))` collapses every absent() call
+  // to the same unlabeled series regardless of x's own label selector
+  // (Prometheus's `absent()` otherwise propagates equality-matched labels
+  // from the selector, which would keep e.g. `up{job="file_host"}`'s check
+  // from `or`-combining cleanly with the label-free ones); `or vector(0)`
+  // is the standard idiom for "1 if anything on the left fired, else 0" —
+  // reasoned through, not verified against a live Prometheus.
+  signal: {
+    title: 'SIGNAL',
+    type: 'stat',
+    id: 905,
+    links: docLink('blind'),
+    targets: [{
+      // Same reasoning as LOOPS above about writing the metric name out
+      // literally rather than interpolating `waker_last_pass`.
+      expr: |||
+        (
+          sum(absent(up{job="file_host"}))
+          or sum(absent(dependency_up))
+          or sum(absent(http_requests_total))
+          or sum(absent(refusals_total))
+          or sum(absent(nudge_waker_last_pass_timestamp_seconds))
+        ) or vector(0)
+      |||,
+      instant: true,
+      refId: 'A',
+    }],
+    fieldConfig: {
+      defaults: {
+        unit: 'none',
+        mappings: [{ type: 'value', options: { '0': { text: 'ok', color: 'green' }, '1': { text: 'BLIND', color: 'red' } } }],
+        color: { mode: 'thresholds' },
+        thresholds: { mode: 'absolute', steps: [{ color: panelDefaults.unknownColor, value: null }] },
+      },
+      overrides: [],
+    },
+    options: { colorMode: 'value', graphMode: 'none', justifyMode: 'center', orientation: 'horizontal', reduceOptions: { calcs: ['lastNotNull'], values: false }, textMode: 'value' },
+  },
+
+  // #213/F4's other half: which build is this, and how long has it been
+  // running. Not one of the six conditions, but the context that makes
+  // reading any of them trustworthy — "how long has it been like this" and
+  // "is this the build I think it is" are the first two questions a red
+  // panel raises. `service_info` is a fixed-1 info gauge; `textMode: 'name'`
+  // renders its labels (via legendFormat) instead of the value, which is
+  // the conventional way to surface an info-metric's labels as text.
+  buildInfo: {
+    title: 'Build',
+    type: 'stat',
+    id: 906,
+    targets: [{ expr: 'service_info', legendFormat: '{{git_sha}} · rustc {{rust}} · built {{built_at}}', instant: true, refId: 'A' }],
+    fieldConfig: {
+      defaults: {
+        unit: 'none',
+        color: { mode: 'fixed', fixedColor: 'text' },
+        thresholds: { mode: 'absolute', steps: [{ color: panelDefaults.unknownColor, value: null }] },
+      },
+      overrides: [],
+    },
+    options: { colorMode: 'none', graphMode: 'none', justifyMode: 'center', orientation: 'horizontal', reduceOptions: { calcs: ['lastNotNull'], values: false }, textMode: 'name' },
+  },
+
+  uptime: {
+    title: 'Uptime',
+    type: 'stat',
+    id: 907,
+    targets: [{ expr: 'time() - process_start_time_seconds', instant: true, refId: 'A' }],
+    fieldConfig: {
+      defaults: {
+        unit: 's',
+        color: { mode: 'fixed', fixedColor: 'text' },
+        thresholds: { mode: 'absolute', steps: [{ color: panelDefaults.unknownColor, value: null }] },
+      },
+      overrides: [],
+    },
+    options: { colorMode: 'none', graphMode: 'none', justifyMode: 'center', orientation: 'horizontal', reduceOptions: { calcs: ['lastNotNull'], values: false }, textMode: 'value' },
+  },
+
+  // The wide timeseries below the stat row — "the shape of the day in one
+  // glance". Outcome-split: served (2xx/3xx), 4xx, 5xx, refused.
+  requestRateByOutcome: {
+    title: 'Request Rate by Outcome',
+    type: 'timeseries',
+    id: 908,
+    targets: [
+      { expr: 'sum(rate(http_requests_total{status=~"2..|3.."}[5m]))', legendFormat: 'served', refId: 'A' },
+      { expr: 'sum(rate(http_requests_total{status=~"4.."}[5m]))', legendFormat: '4xx', refId: 'B' },
+      { expr: 'sum(rate(http_requests_total{status=~"5.."}[5m]))', legendFormat: '5xx', refId: 'C' },
+      { expr: 'sum(rate(refusals_total[5m]))', legendFormat: 'refused', refId: 'D' },
+    ],
+    fieldConfig: {
+      defaults: {
+        unit: 'reqps',
+        custom: { drawStyle: 'line', fillOpacity: 15, lineWidth: 2, pointSize: 4, showPoints: 'never', spanNulls: false, stacking: { mode: 'normal' } },
+        color: { mode: 'palette-classic' },
+      },
+      overrides: [
+        { matcher: { id: 'byName', options: '5xx' }, properties: [{ id: 'color', value: { mode: 'fixed', fixedColor: 'red' } }] },
+        { matcher: { id: 'byName', options: 'refused' }, properties: [{ id: 'color', value: { mode: 'fixed', fixedColor: 'orange' } }] },
+        { matcher: { id: 'byName', options: 'served' }, properties: [{ id: 'color', value: { mode: 'fixed', fixedColor: 'green' } }] },
+      ],
+    },
+    options: { legend: { showLegend: true, placement: 'bottom' }, tooltip: { mode: 'multi', sort: 'desc' } },
+  },
+
+  // #213/F2's duration histogram, dashboarded — per-route latency across
+  // the whole HTTP surface, distinct from `operationDuration` below (which
+  // is `operation_duration_seconds`, a narrower per-operation/phase
+  // histogram from `metrics::instruments`). Buckets are
+  // `metrics::http::HTTP_DURATION_BUCKETS` — the top one sits above the
+  // 15s request timeout on purpose, so a request that times out still
+  // lands in a real bucket instead of falling off into `+Inf`.
+  httpLatencyByRoute: {
+    title: 'HTTP Latency by Route (P95)',
+    type: 'timeseries',
+    id: 909,
+    targets: [{ expr: 'histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, route))', legendFormat: '{{route}}', refId: 'A' }],
+    fieldConfig: {
+      defaults: {
+        unit: 's',
+        custom: { drawStyle: 'line', fillOpacity: 10, lineWidth: 2, pointSize: 4, showPoints: 'never', spanNulls: false, stacking: { mode: 'none' } },
+        color: { mode: 'palette-classic' },
+      },
+      overrides: [],
+    },
+    options: { legend: { showLegend: true, placement: 'right', calcs: ['last', 'max'] }, tooltip: { mode: 'multi', sort: 'desc' } },
+  },
+}

--- a/infra/grafana/generated/dashboard.json
+++ b/infra/grafana/generated/dashboard.json
@@ -12,6 +12,19 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "changes(process_start_time_seconds[$__interval]) > 0",
+        "iconColor": "purple",
+        "name": "Restarts",
+        "step": "60s",
+        "titleFormat": "file_host restarted",
+        "type": "dashboard"
       }
     ]
   },
@@ -22,6 +35,776 @@
   "links": [],
   "liveNow": false,
   "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "#8E8E8E",
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            },
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "#8E8E8E",
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#8E8E8E",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 900,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "What this means",
+          "url": "https://github.com/paulgsc/server/blob/main/docs/fault-conditions.md#unreachable"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "name_and_value"
+      },
+      "targets": [
+        {
+          "expr": "up{job=\"file_host\"}",
+          "instant": true,
+          "legendFormat": "file_host",
+          "refId": "A"
+        }
+      ],
+      "title": "UP",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "#8E8E8E",
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 3
+              }
+            ]
+          },
+          "unit": "/3"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 901,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "What this means",
+          "url": "https://github.com/paulgsc/server/blob/main/docs/fault-conditions.md#dependency-down"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "sum(dependency_up)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DEPS",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "#8E8E8E",
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.001
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 902,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "What this means",
+          "url": "https://github.com/paulgsc/server/blob/main/docs/fault-conditions.md#rejecting"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m]))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "ERRORS",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "#8E8E8E",
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.001
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 903,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "What this means",
+          "url": "https://github.com/paulgsc/server/blob/main/docs/fault-conditions.md#saturated"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(refusals_total[5m]))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "REFUSALS",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "text": "ok"
+                },
+                "1": {
+                  "color": "red",
+                  "text": "STALLED"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "#8E8E8E",
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#8E8E8E",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 904,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "What this means",
+          "url": "https://github.com/paulgsc/server/blob/main/docs/fault-conditions.md#stalled"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "(time() - nudge_waker_last_pass_timestamp_seconds) > bool 900",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "LOOPS",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "text": "ok"
+                },
+                "1": {
+                  "color": "red",
+                  "text": "BLIND"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "#8E8E8E",
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#8E8E8E",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 905,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "What this means",
+          "url": "https://github.com/paulgsc/server/blob/main/docs/fault-conditions.md#blind"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "(\n  sum(absent(up{job=\"file_host\"}))\n  or sum(absent(dependency_up))\n  or sum(absent(http_requests_total))\n  or sum(absent(refusals_total))\n  or sum(absent(nudge_waker_last_pass_timestamp_seconds))\n) or vector(0)\n",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "SIGNAL",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "#8E8E8E",
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#8E8E8E",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 18,
+        "x": 0,
+        "y": 4
+      },
+      "id": 906,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "name"
+      },
+      "targets": [
+        {
+          "expr": "service_info",
+          "instant": true,
+          "legendFormat": "{{git_sha}} · rustc {{rust}} · built {{built_at}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Build",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "text",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "#8E8E8E",
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#8E8E8E",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
+      "id": 907,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "time() - process_start_time_seconds",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "refused"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "served"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 908,
+      "options": {
+        "legend": {
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status=~\"2..|3..\"}[5m]))",
+          "legendFormat": "served",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{status=~\"4..\"}[5m]))",
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m]))",
+          "legendFormat": "5xx",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(refusals_total[5m]))",
+          "legendFormat": "refused",
+          "refId": "D"
+        }
+      ],
+      "title": "Request Rate by Outcome",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 909,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, route))",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Latency by Route (P95)",
+      "type": "timeseries"
+    },
     {
       "datasource": {
         "type": "prometheus",
@@ -65,7 +848,7 @@
         "h": 4,
         "w": 6,
         "x": 0,
-        "y": 0
+        "y": 18
       },
       "id": 1,
       "options": {
@@ -148,7 +931,7 @@
         "h": 4,
         "w": 6,
         "x": 6,
-        "y": 0
+        "y": 18
       },
       "id": 2,
       "options": {
@@ -222,7 +1005,7 @@
         "h": 4,
         "w": 6,
         "x": 12,
-        "y": 0
+        "y": 18
       },
       "id": 4,
       "options": {
@@ -291,7 +1074,7 @@
         "h": 4,
         "w": 6,
         "x": 18,
-        "y": 0
+        "y": 18
       },
       "id": 5,
       "options": {
@@ -358,7 +1141,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 4
+        "y": 22
       },
       "id": 3,
       "options": {
@@ -422,7 +1205,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 4
+        "y": 22
       },
       "id": 6,
       "options": {
@@ -498,9 +1281,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 12
+        "y": 30
       },
       "id": 9,
       "options": {
@@ -522,105 +1305,16 @@
       ],
       "title": "⚙️ Operation Duration (P95)",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "red",
-                  "text": "DOWN"
-                },
-                "1": {
-                  "color": "green",
-                  "text": "UP"
-                }
-              },
-              "type": "value"
-            },
-            {
-              "options": {
-                "match": "null+nan",
-                "result": {
-                  "color": "#8E8E8E",
-                  "text": "no data"
-                }
-              },
-              "type": "special"
-            },
-            {
-              "options": {
-                "match": "null+nan",
-                "result": {
-                  "color": "#8E8E8E",
-                  "text": "no data"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "noValue": "no data",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "#8E8E8E",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 12
-      },
-      "id": 15,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "values": false
-        },
-        "textMode": "name_and_value"
-      },
-      "targets": [
-        {
-          "expr": "up{job=\"file_host\"}",
-          "instant": true,
-          "legendFormat": "file_host",
-          "refId": "A"
-        }
-      ],
-      "title": "file_host liveness",
-      "type": "stat"
     }
   ],
-  "refresh": "10s",
+  "refresh": "5s",
   "schemaVersion": 38,
   "tags": [
     "rust",
     "axum",
     "prometheus",
-    "sla"
+    "sla",
+    "health"
   ],
   "templating": {
     "list": []
@@ -631,7 +1325,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "🚀 Service Uptime & Performance Dashboard",
+  "title": "🩺 file_host Operational Dashboard",
   "uid": "file-host-dashboard",
   "version": 1
 }

--- a/scripts/check_metric_contract.py
+++ b/scripts/check_metric_contract.py
@@ -63,6 +63,7 @@ EXEMPT_QUERIED_PREFIXES: dict[str, str] = {
 EXEMPT_QUERIED_EXACT: dict[str, str] = {
 	"up": "Prometheus's own per-target scrape-health series",
 	"ALERTS": "Prometheus's own built-in firing-alerts series",
+	"nudge_waker_last_pass_timestamp_seconds": "owned by #236 ([PUSH] P4), not yet landed — the HEALTH row's LOOPS/SIGNAL panels (#213/#225) query it ahead of the emitter on purpose, per #219's rule that an absent series renders grey rather than green",
 }
 
 # Metrics this workspace emits through the `metrics` facade with no
@@ -76,7 +77,14 @@ EXEMPT_EMITTED: dict[str, str] = {
 	"file_size_bytes": "file_host download-size histogram; no dedicated panel yet, same as operation_errors_total",
 }
 
-METRICS_FACADE_CALL = re.compile(r'\b(?:counter|histogram|gauge)!\s*\(\s*"([^"]+)"')
+METRICS_FACADE_CALL = re.compile(r'\b(?:counter|histogram|gauge)!\s*\(\s*(?:"([^"]+)"|([A-Z_][A-Z0-9_]*))')
+
+# `histogram!(HTTP_DURATION_METRIC, ...)` — a call site naming its metric via
+# a constant instead of a literal, so the name can't drift from wherever else
+# that constant is used (e.g. a `PrometheusBuilder::set_buckets_for_metric`
+# call needing the identical name). Resolved by first collecting every
+# `const NAME: &str = "literal"` in the workspace, then substituting.
+CONST_STR_DECL = re.compile(r'\bconst\s+([A-Z_][A-Z0-9_]*)\s*:\s*&(?:\'static\s+)?str\s*=\s*"([^"]+)"')
 
 # Prometheus expands a histogram's base name into `_bucket`/`_sum`/`_count`
 # series at scrape time; a dashboard querying one of those is querying the
@@ -133,15 +141,29 @@ def rust_source_files() -> list[Path]:
 	return sorted(files)
 
 
+def const_str_declarations(files: list[Path]) -> dict[str, str]:
+	"""`const NAME: &str = "literal"` -> literal, across every given file."""
+	consts: dict[str, str] = {}
+	for path in files:
+		for match in CONST_STR_DECL.finditer(path.read_text()):
+			consts[match.group(1)] = match.group(2)
+	return consts
+
+
 def emitted_metrics() -> dict[str, list[str]]:
 	"""metric name -> sorted list of `path:line` call sites."""
+	files = rust_source_files()
+	consts = const_str_declarations(files)
+
 	sites: dict[str, list[str]] = {}
-	for path in rust_source_files():
+	for path in files:
 		text = path.read_text()
 		# Whole-file, not line-by-line: `counter!(\n  "name", ...)` — the
 		# facade's multi-arg calls routinely put the name on its own line.
 		for match in METRICS_FACADE_CALL.finditer(text):
-			name = match.group(1)
+			name = match.group(1) if match.group(1) is not None else consts.get(match.group(2))
+			if name is None:
+				continue  # a non-const, non-literal first argument (e.g. a runtime String) — not lexically resolvable, and not a name this check can assert about either way
 			lineno = text.count("\n", 0, match.start()) + 1
 			sites.setdefault(name, []).append(f"{path.relative_to(REPO_ROOT)}:{lineno}")
 	return sites


### PR DESCRIPTION
## Description

Lands epic #213 (`[EPIC][FAULT] "Is the server in a fault state" — six conditions, strictly defined`), now that #212 established the "no data ≠ healthy" dashboard convention this epic is built on. Covers all five stories: #221, #222, #223, #224, #225.

**The problem this epic exists for**: before this PR, "is the server in a fault state" was unanswerable. `/health` returned a compile-time string literal (`"healthy"`, always). There was no HTTP request metric anywhere in the workspace. Eight distinct refusal paths (timeout, load-shed, body-limit, three WS admission refusals) logged a `warn!`/`error!` and counted nothing. Nothing recorded which build was even running — every crate pins `version = "0.0.0"`, so `env!("CARGO_PKG_VERSION")` has never changed and never will.

Fixes #213 
Fixes #221 
Fixes #222 
Fixes #223 
Fixes #224 
Fixes #225

## What changed

- **F1 (#221) — `/health` and `/ready` stop being the same question**: new `GET /ready` (`handlers::readiness`) checks SQLite (bounded query), NATS (a non-blocking connection-state read — `some-transport` gained a small `is_connected()` to support it), and Redis (bounded `PING`), all concurrently, exporting `dependency_up{dependency}` gauges and a 503 JSON breakdown naming whichever dependency failed. `/health` stays a pure liveness probe, unchanged. The compose healthcheck (`--health-check`) now targets `/ready` — verified this doesn't reintroduce the crash-loop failure mode the split exists to prevent, since Compose's healthcheck only gates `depends_on`/`docker ps` status here, not container restarts. Both routes registered in `routes/inventory.rs`.

- **F2 (#222) — `http_requests_total{route,method,status}`**: `metrics::http::track_http_metrics` records request counts and a duration histogram, labelled by axum's *matched route pattern* (via `MatchedPath`), never the raw request path — cardinality stays bounded to the ~40-route inventory plus one `route="unmatched"` bucket for anything that didn't match (via a dedicated `.fallback()` handler, since `.layer()` middleware doesn't see fallback traffic). Histogram buckets extend to 30s so a request that hits the 15s `TimeoutLayer` still lands in a real bucket instead of falling off into `+Inf`. A new test (`matched_path_equals_route_inventory_full_path`) drives every declared route through the real middleware stack and asserts the captured label is exactly `routes::inventory`'s own `full_path()` — this is what "the route label values are a subset of the inventory" (the story's own acceptance criterion) is checked by.

- **F3 (#223) — refusals become counters, not just log lines**: `refusals_total{stage,reason}` sits next to the existing `warn!`/`error!` at each site — timeout and load-shed in `handle_tower_error`, body-limit via a dedicated wrapper (`RequestBodyLimitLayer` answers in-layer and never reaches `handle_tower_error`, so it needed its own), and all three WebSocket admission refusals in `websocket_handler`. Concurrency-limit queueing (`tower::limit::ConcurrencyLimitLayer`) has no discrete refusal event at all in tower 0.4 — it's pure backpressure with no error type — documented as such in `metrics::refusals` rather than faked with a synthetic counter that doesn't correspond to anything tower actually does.

- **F4 (#224) — `service_info` and uptime**: `apps/servers/file_host/build.rs` is new — the workspace-root `build.rs` was never actually wired to any package's build (no `[package]` in the workspace manifest), so this had to move. Stamps git SHA (+dirty marker), build timestamp, and rustc version, preferring `VCS_REF`/`BUILD_DATE` build args (Docker's build context has no `.git`) with a `git`-command fallback for local/CI builds where it does. `service_info{service,version,git_sha,built_at,rust}` (fixed at 1, the conventional info-gauge shape) and `process_start_time_seconds` export once at startup; the same identity rides in `/ready`'s JSON so it survives Prometheus being down. `Dockerfile.server`'s builder stage and `.github/actions/docker-build` now actually pass those build args through the pipeline — they were previously declared `ARG`s that only ever resolved to `"unknown"`, wired to the wrong (runtime-only) stage.

- **F5 (#225) — the HEALTH row**: six panels at the top of `dashboard.jsonnet` — UP, DEPS, ERRORS, REFUSALS, LOOPS, SIGNAL — ordered by diagnostic precedence, built on #219's shared panel defaults (`panelDefaults.hardenAll`) so none of them can render green on absent data. LOOPS and SIGNAL query `nudge_waker_last_pass_timestamp_seconds`, owned by the sibling epic #236 ([PUSH] P4) which hasn't landed yet — an explicit, reasoned `EXEMPT_QUERIED` entry in the G1 metric-contract check, and the panels render grey (unknown), not green, until that story ships — no dashboard change required when it does. Also added: a build-identity panel and an uptime panel (`process_start_time_seconds`), a restart annotation (`changes(process_start_time_seconds[$__interval]) > 0`), and a wide outcome-split request-rate timeseries. New `docs/fault-conditions.md` is the strict six-condition reference every panel links back to.

`scripts/check_metric_contract.py` also gained resolution of `const NAME: &str = "literal"` metric names — `histogram!(HTTP_DURATION_METRIC, ...)` would otherwise have been invisible to it, and the checker actually seeing what's emitted was the entire point of #217.

## How this was verified

- `cargo check --workspace` and `cargo test -p file_host --lib` (41 tests, including the new route-inventory/metrics-middleware test) both pass clean.
- `python3 scripts/check_metric_contract.py` passes on the resulting tree (15 emitted metrics, 74 queried metrics).
- `jsonnet -J lib` builds all four active dashboards cleanly, byte-identical to what's checked in.
- Every **new** file (`readiness.rs`, `metrics/http.rs`, `metrics/refusals.rs`, `metrics/build_info.rs`, `build.rs`) is clippy-clean under this workspace's full `pedantic`+`nursery` config (`-D warnings`) — verified directly, not assumed. Edits to already-dirty pre-existing files (`websocket.rs`, `some-transport/nats/transport.rs`) introduce **zero new** clippy violations — verified by isolating clippy's output to the specific lines changed and confirming every flagged line in those files is pre-existing, untouched code.
- This branch also carries the separately-diagnosed, separately-merged Docker CI fix (#240) via rebase, so `cargo check --workspace` reflects the current state of `main`.
- **Not verified live**: a running `docker compose up` stack (no docker daemon in this environment) — so `/ready`'s actual 503 behavior against a killed dependency, the HEALTH row's live rendering, and the restart annotation are verified by code review and the automated test above, not by watching Prometheus scrape a real process. Recommend a manual pass (`docker stop nats`, confirm `/ready` 503s naming NATS and DEPS reddens within one scrape interval) before/after merge.

## Type of change

- [x] Bug fix (`/health` answering nothing about dependency state; eight uncounted refusal paths)
- [x] New feature (readiness endpoint, HTTP/refusal metrics, build identity, HEALTH dashboard row)
- [ ] Breaking change
- [x] Documentation update (`docs/fault-conditions.md`)

## Checklist

- [x] My changes generate no new clippy warnings (verified per-file, see above)
- [x] I have added tests that prove the fix works (`metrics::http::tests`, existing `routes::inventory` suite still green)
- [x] New and existing unit tests pass locally (41/41)
- [ ] Verified live against a running Grafana/Prometheus/docker-compose stack (blocked on docker daemon availability in this environment — see above)


---
_Generated by [Claude Code](https://claude.ai/code/session_0127Q1cND2S99KDuMQWTQZhB)_