### PR TITLE
feat(observability): CLIENTS row — WS connection metrics, presence gauges, SQLite pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,12 +1682,12 @@ dependencies = [
  "lazy_static",
  "log 0.4.28",
  "metrics",
+ "metrics-util",
  "mood_event",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "polars",
- "prometheus",
  "push_kit",
  "push_repo",
  "rand 0.9.2",
@@ -3256,7 +3256,9 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
+ "indexmap 2.12.1",
  "metrics",
+ "ordered-float",
  "quanta",
  "rand 0.9.2",
  "rand_xoshiro",
@@ -3788,6 +3790,15 @@ dependencies = [
  "tracing-subscriber",
  "ws-connection",
  "ws-events",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4715,21 +4726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4774,12 +4770,6 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,11 +93,16 @@ futures = "0.3.26"
 lazy_static = "1.4.0"
 metrics = "0.24.6"
 metrics-exporter-prometheus = { version = "0.18.3", default-features = false }
+# Test-only: `metrics_util::debugging::DebuggingRecorder`, used to assert
+# recorded values without a live Prometheus — see #226 (C1)'s acceptance
+# criterion that connection lifecycle counters have at least one test. Same
+# 0.20.4 already resolved transitively through metrics-exporter-prometheus,
+# pinned explicitly rather than left to drift since it's now a direct dep.
+metrics-util = { version = "0.20.4", default-features = false, features = ["debugging"] }
 mime = "0.3.17"
 notify = "6.1.1"
 once_cell = "1.17.1"
 proc-macro2 = "1.0.79"
-prometheus = "0.13.4"
 quote = "1.0.23"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"

--- a/apps/servers/file_host/Cargo.toml
+++ b/apps/servers/file_host/Cargo.toml
@@ -43,7 +43,6 @@ garde = { version =  "0.22.0", features = ["full"] }
 log = "0.4.14"
 lazy_static = { workspace = true }
 futures = { workspace = true }
-prometheus = { workspace = true }
 redis = { version = "0.28.2", features = ["aio", "tokio-comp"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -87,6 +86,7 @@ chrono-tz = "0.10"
 # `test-util` gives the paused clock the sliding-window rate limiter tests use
 # to step over a sixty-second window without sleeping for it.
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+metrics-util = { workspace = true }
 
 [lints]
 workspace = true

--- a/apps/servers/file_host/src/main.rs
+++ b/apps/servers/file_host/src/main.rs
@@ -92,6 +92,11 @@ async fn main() -> Result<()> {
 	// from a gap in an unrelated series.
 	file_host::metrics::build_info::record();
 
+	// #227 (C2): the configured ceiling `ws_connection_guard_occupancy` is
+	// measured against, stamped once for the same reason build info is —
+	// fixed for the process's life, so no reason to recompute it every tick.
+	file_host::websocket::connection::instrument::set_guard_capacity(ws_conn_manager::MAX_GLOBAL);
+
 	let config = Arc::new(config);
 	let connection_options = SqliteConnectOptions::from_str(&config.database_url)?
 		.create_if_missing(true)
@@ -176,6 +181,15 @@ async fn main() -> Result<()> {
 	} else {
 		tracing::info!("engagement waker is not running; /api/v1/push and /api/v1/signals still work");
 	}
+
+	// #227 (C2) / #228 (C3): `connected`/`live`/`subscribed`, guard
+	// occupancy, and SQLite pool gauges — unconditional, unlike the nudge
+	// waker above, since none of them depend on optional configuration.
+	// `file_host::websocket::STALE_TIMEOUT` is the same "recently heard
+	// from" window the WS message loop already uses for its own stale
+	// check, so `live` here and the connections it actually closes agree on
+	// what "recent" means.
+	file_host::metrics::periodic::spawn(app_state.clone(), file_host::websocket::STALE_TIMEOUT, Duration::from_secs(10));
 
 	let listener = TcpListener::bind("0.0.0.0:3000").await?;
 	tracing::debug!("listening on {}", listener.local_addr()?);

--- a/apps/servers/file_host/src/metrics.rs
+++ b/apps/servers/file_host/src/metrics.rs
@@ -1,12 +1,14 @@
-#[allow(dead_code)]
+// #226 (C1): these were all live already but sat behind `#[allow(dead_code)]`
+// dating from before #213 gave each one a real call site — see
+// `websocket/connection/instrument.rs`'s header for the sibling module that
+// had the opposite problem (declared, never called). Removed here so the
+// lint gate covers this module again.
 pub mod build_info;
-#[allow(dead_code)]
 pub mod http;
-#[allow(dead_code)]
 pub mod instruments;
-#[allow(dead_code)]
 pub mod observability;
-#[allow(dead_code)]
+pub mod periodic;
+pub mod pool;
 pub mod refusals;
 
 #[allow(unused_imports)]

--- a/apps/servers/file_host/src/metrics/periodic.rs
+++ b/apps/servers/file_host/src/metrics/periodic.rs
@@ -1,0 +1,42 @@
+//! Gauges that must not be sampled from the request or scrape path — see
+//! #227 (C2) and #228 (C3).
+//!
+//! `WebSocketFsm::connection_gauges` awaits every connection actor to answer
+//! `live`/`subscribed`, which is fine on a periodic sweep and not fine on
+//! every `/metrics` scrape at scale (#227's own task list says so). The
+//! SQLite pool gauges are cheap synchronous reads, but sampling them here
+//! too keeps this one place responsible for every gauge that isn't updated
+//! from its own mutation site, rather than growing a second spawned loop
+//! for a handful of `gauge!` calls that cost nothing extra to batch in.
+
+use crate::websocket::connection::instrument;
+use crate::AppState;
+use std::time::Duration;
+use tracing::info;
+
+/// Spawn the periodic gauge refresh, cancelled through the shared token.
+/// Unconditional — unlike the nudge waker, there is no configuration under
+/// which these gauges shouldn't run.
+pub fn spawn(state: AppState, freshness: Duration, interval: Duration) {
+	let cancel = state.core.cancel_token.clone();
+
+	tokio::spawn(async move {
+		info!(interval_secs = interval.as_secs(), "operational gauge refresh started");
+		let mut tick = tokio::time::interval(interval);
+
+		loop {
+			tokio::select! {
+				() = cancel.cancelled() => {
+					info!("operational gauge refresh cancelled");
+					return;
+				}
+				_ = tick.tick() => {
+					let snapshot = state.realtime.ws.connection_gauges(freshness).await;
+					instrument::set_presence_gauges(snapshot.connected, snapshot.live, snapshot.subscribed);
+					instrument::set_guard_occupancy(state.core.connection_guard.active_global());
+					crate::metrics::pool::record(&state.core.shared_db);
+				}
+			}
+		}
+	});
+}

--- a/apps/servers/file_host/src/metrics/pool.rs
+++ b/apps/servers/file_host/src/metrics/pool.rs
@@ -1,0 +1,20 @@
+//! `sqlite_pool_size` / `sqlite_pool_idle` — see #228 (C3).
+//!
+//! The shared SQLite pool (`main.rs`) is `max_connections(5)`, split across
+//! six repository crates, with a 5-second `busy_timeout`. Pool exhaustion is
+//! reachable — #203 documents a repository taking a second connection while
+//! holding a write transaction against that same pool of five — and today
+//! it is observable only as requests mysteriously taking five seconds and
+//! then failing. `sqlx::Pool::size()`/`num_idle()` are already tracked by
+//! the pool itself, so this needs no instrumentation of any individual
+//! query: idle hitting zero while size sits at the configured max is
+//! visible before the `busy_timeout` turns it into a user-visible failure.
+
+use metrics::gauge;
+use sqlx::SqlitePool;
+
+pub fn record(pool: &SqlitePool) {
+	gauge!("sqlite_pool_size").set(f64::from(pool.size()));
+	#[allow(clippy::cast_precision_loss)]
+	gauge!("sqlite_pool_idle").set(pool.num_idle() as f64);
+}

--- a/apps/servers/file_host/src/websocket.rs
+++ b/apps/servers/file_host/src/websocket.rs
@@ -12,7 +12,7 @@ use axum::{
 use futures::stream::StreamExt;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::task::JoinHandle;
-use tokio::time::{timeout, Duration};
+use tokio::time::{timeout, Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 use ws_conn_manager::{AcquireErrorKind, ConnectionPermit};
@@ -26,8 +26,16 @@ pub mod message;
 pub mod shutdown;
 
 use broadcast::spawn_event_forwarder;
-use connection::{clear_connection, establish_connection, send_initial_handshake};
+use connection::{clear_connection, client_type_label, establish_connection, instrument, send_initial_handshake};
 use message::spawn_process_incoming_messages;
+
+/// How long a connection's message-processing loop will let it sit without
+/// inbound activity before treating it as stale — see
+/// `message::handlers::process_incoming_messages`. Also the "freshness"
+/// window `connection_gauges`/`nudge::presence` use for `live`: the same
+/// question ("has anyone been heard from recently") answered the same way in
+/// both places, rather than two timeouts that could silently drift apart.
+pub const STALE_TIMEOUT: Duration = Duration::from_secs(120);
 
 // Enhanced WebSocket FSM with comprehensive observability
 #[derive(Clone)]
@@ -61,14 +69,30 @@ impl WebSocketFsm {
 	///
 	/// Exists so the nudge sender can ask about presence without reaching into
 	/// the connection store — see `nudge::presence` for the reasoning behind
-	/// treating the answer as an input rather than a veto.
+	/// treating the answer as an input rather than a veto. A thin wrapper over
+	/// [`Self::connection_gauges`], which also answers `subscribed` for #227's
+	/// dashboard row; kept as its own method so `nudge::presence`'s call site
+	/// doesn't have to know about — or pay for computing — a number it
+	/// doesn't use.
 	pub async fn live_connection_count(&self, freshness: Duration) -> (usize, usize) {
+		let snapshot = self.connection_gauges(freshness).await;
+		(snapshot.connected, snapshot.live)
+	}
+
+	/// `connected` / `live` / `subscribed` — see #227. Awaits every
+	/// connection actor, so this belongs on a periodic background sweep
+	/// (`metrics::periodic`), never on the request or scrape path; `connected`
+	/// alone is cheap and is also refreshed synchronously from
+	/// `add_connection`/`remove_connection`.
+	pub async fn connection_gauges(&self, freshness: Duration) -> ConnectionGaugeSnapshot {
 		let keys = self.store.keys();
 		let connected = keys.len();
 		let mut live = 0;
+		let mut subscribed = 0;
 
 		for key in keys {
 			let Some(handle) = self.store.get(&key) else { continue };
+
 			// An actor that cannot answer is not evidence of anyone being
 			// present, so a failed query counts as absence rather than
 			// propagating — presence must never be able to fail *closed*.
@@ -77,20 +101,43 @@ impl WebSocketFsm {
 					live += 1;
 				}
 			}
+
+			if let Ok(subs) = handle.get_subscriptions().await {
+				if !subs.is_empty() {
+					subscribed += 1;
+				}
+			}
 		}
 
-		(connected, live)
+		ConnectionGaugeSnapshot { connected, live, subscribed }
 	}
+}
+
+/// See [`WebSocketFsm::connection_gauges`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ConnectionGaugeSnapshot {
+	pub connected: usize,
+	pub live: usize,
+	pub subscribed: usize,
 }
 
 struct ConnectionCleanup {
 	forward_task: Option<JoinHandle<()>>,
-	message_task: Option<JoinHandle<u64>>,
+	message_task: Option<JoinHandle<(u64, &'static str)>>,
 
 	forward_cancel: CancellationToken,
 	process_cancel: CancellationToken,
 
 	permit: Option<ConnectionPermit>,
+
+	/// The single choke point every socket's teardown passes through exactly
+	/// once — see #226/#227 and this module's `instrument` doc comment.
+	/// `client_type`/`started_at` are fixed at construction; `end_reason` is
+	/// set by `handle_socket` right before this drops, from whichever
+	/// `tokio::select!` branch actually explains the teardown.
+	client_type: &'static str,
+	started_at: Instant,
+	end_reason: &'static str,
 }
 
 impl Drop for ConnectionCleanup {
@@ -109,6 +156,8 @@ impl Drop for ConnectionCleanup {
 		if let Some(permit) = self.permit.take() {
 			permit.release();
 		}
+
+		instrument::record_removed(self.client_type, self.end_reason, self.started_at.elapsed().as_secs_f64());
 	}
 }
 
@@ -166,8 +215,10 @@ async fn handle_socket(socket: WebSocket, state: AppState, headers: HeaderMap, a
 		}
 	};
 
+	let client_type = client_type_label(&ws_fsm.client_id_from_request(&headers, &addr));
+
 	if send_initial_handshake(&mut sender).await.is_err() {
-		clear_connection(&ws_fsm, &conn_key).await;
+		clear_connection(&ws_fsm, &conn_key, client_type).await;
 		return;
 	}
 
@@ -185,14 +236,136 @@ async fn handle_socket(socket: WebSocket, state: AppState, headers: HeaderMap, a
 		message_task: Some(message_task),
 		forward_cancel,
 		process_cancel,
+		client_type,
+		started_at: Instant::now(),
+		end_reason: "cleanup",
 	};
 
-	tokio::select! {
-		_ = cleanup.forward_task.as_mut().unwrap() => {},
-		_ = cleanup.message_task.as_mut().unwrap() => {},
-		_ = cancel_token.cancelled() => {},
-	}
+	// Which branch resolves first is *how* the connection ended; the actual
+	// `end_reason` label comes from there, except cancellation always wins —
+	// see below. `message_task`'s own reason (set by
+	// `process_incoming_messages`) is the informative case; `forward_task`
+	// ending on its own means the outbound side hit a send failure (the peer
+	// is gone) or ran out of channels, both of which read as the client
+	// having left.
+	let resolved_reason: &'static str = tokio::select! {
+		_ = cleanup.forward_task.as_mut().unwrap() => "client_disconnect",
+		result = cleanup.message_task.as_mut().unwrap() => match result {
+			Ok((_, reason)) => reason,
+			Err(_) => "error", // task panicked or was aborted
+		},
+		_ = cancel_token.cancelled() => "cleanup",
+	};
+
+	// A server-shutdown cancellation racing one of the other two branches can
+	// make either of them resolve "first" even though shutdown is why the
+	// connection is really ending — `is_cancelled()` overrides whatever the
+	// select above picked so that race can't mislabel a shutdown as a client
+	// disconnect or an error.
+	cleanup.end_reason = if cancel_token.is_cancelled() { "cleanup" } else { resolved_reason };
 }
 
 // Re-export for compatibility
 pub use WebSocketFsm as WebSocketState;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+	use metrics_util::CompositeKey;
+
+	type Snapshot = Vec<(CompositeKey, Option<metrics::Unit>, Option<metrics::SharedString>, DebugValue)>;
+
+	fn find<'a>(snapshot: &'a Snapshot, name: &str, labels: &[(&str, &str)]) -> Option<&'a DebugValue> {
+		snapshot.iter().find_map(|(key, _, _, value)| {
+			let k = key.key();
+			if k.name() != name {
+				return None;
+			}
+			let matches = labels.iter().all(|(want_k, want_v)| k.labels().any(|l| l.key() == *want_k && l.value() == *want_v));
+			matches.then_some(value)
+		})
+	}
+
+	fn counter(snapshot: &Snapshot, name: &str, labels: &[(&str, &str)]) -> Option<u64> {
+		match find(snapshot, name, labels) {
+			Some(DebugValue::Counter(n)) => Some(*n),
+			_ => None,
+		}
+	}
+
+	fn gauge(snapshot: &Snapshot, name: &str, labels: &[(&str, &str)]) -> Option<f64> {
+		match find(snapshot, name, labels) {
+			Some(DebugValue::Gauge(n)) => Some(n.into_inner()),
+			_ => None,
+		}
+	}
+
+	/// #226 (C1)'s acceptance criterion: "opening a WebSocket and closing it
+	/// moves `ws_connection_lifecycle_total{event="created"}` and
+	/// `{event="removed"}`, and records a duration under a real
+	/// `end_reason`." Exercised through `WebSocketFsm` and `ConnectionCleanup`
+	/// directly rather than a real socket — those are the two seams that
+	/// actually record the metrics (`add_connection` for `created`,
+	/// `ConnectionCleanup::drop` for `removed`/duration — see this module's
+	/// header comment on `instrument` for why they're split), and a live
+	/// axum/tokio-tungstenite round trip would exercise a lot of unrelated
+	/// machinery to reach the same two call sites.
+	#[test]
+	fn opening_and_closing_a_connection_moves_the_lifecycle_counters() {
+		let recorder = DebuggingRecorder::new();
+		let snapshotter = recorder.snapshotter();
+
+		metrics::with_local_recorder(&recorder, || {
+			let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().expect("build a current-thread runtime");
+
+			rt.block_on(async {
+				let fsm = WebSocketFsm::new();
+				let headers = HeaderMap::new();
+				let addr: SocketAddr = "127.0.0.1:9999".parse().expect("valid socket addr");
+				let cancel = CancellationToken::new();
+
+				// "Opening a WebSocket": the store-level half of connection
+				// setup — the half that doesn't need a real TCP socket. Not
+				// snapshotting here: `Snapshotter::snapshot()` swaps counter
+				// and gauge storage back to zero as it reads it, so an
+				// intermediate check here would consume the very count the
+				// assertions below are looking for.
+				let key = fsm.add_connection(&headers, &addr, &cancel).await.expect("add_connection");
+
+				// "Closing it": the store entry goes first, the way every
+				// real removal path in `message`/`broadcast` handlers calls
+				// it before `ConnectionCleanup` ever drops.
+				fsm.remove_connection(&key, "test teardown".to_string()).await.expect("remove_connection");
+
+				// The socket-level half — built directly rather than through
+				// `handle_socket`'s full upgrade dance, since `Drop` is the
+				// only part of it this test needs.
+				let cleanup = ConnectionCleanup {
+					forward_task: Some(tokio::spawn(async {})),
+					message_task: Some(tokio::spawn(async { (0u64, "client_disconnect") })),
+					forward_cancel: CancellationToken::new(),
+					process_cancel: CancellationToken::new(),
+					permit: None,
+					client_type: "direct",
+					started_at: Instant::now(),
+					end_reason: "client_disconnect",
+				};
+				drop(cleanup);
+			});
+		});
+
+		let snapshot = snapshotter.snapshot().into_vec();
+
+		assert_eq!(counter(&snapshot, "ws_connection_lifecycle_total", &[("event", "created")]), Some(1));
+		assert_eq!(counter(&snapshot, "ws_connection_lifecycle_total", &[("event", "removed")]), Some(1));
+		assert_eq!(gauge(&snapshot, "ws_connections", &[("state", "connected")]), Some(0.0));
+
+		let DebugValue::Histogram(samples) =
+			find(&snapshot, "ws_connection_duration_seconds", &[("end_reason", "client_disconnect")]).expect("duration recorded under a real end_reason")
+		else {
+			panic!("ws_connection_duration_seconds should be a histogram");
+		};
+		assert_eq!(samples.len(), 1);
+	}
+}

--- a/apps/servers/file_host/src/websocket/connection.rs
+++ b/apps/servers/file_host/src/websocket/connection.rs
@@ -14,6 +14,21 @@ pub mod instrument;
 use errors::ConnectionError;
 pub(crate) use handlers::{clear_connection, establish_connection, send_initial_handshake};
 
+/// `client_type` label for [`instrument::record_created`]/[`instrument::record_removed`]
+/// and `ConnectionCleanup`'s own decrement in `websocket.rs` — the same
+/// `auth:`/`proxy:`/`direct:` prefix convention `client_id_from_request`
+/// writes, read back out. A free function rather than a method so
+/// `websocket.rs` can derive the label without going through the store.
+pub(crate) fn client_type_label(client_id: &ClientId) -> &'static str {
+	if client_id.as_str().starts_with("auth:") {
+		"auth"
+	} else if client_id.as_str().starts_with("proxy:") {
+		"proxy"
+	} else {
+		"direct"
+	}
+}
+
 // Connection management operations
 impl WebSocketFsm {
 	/// Generate a ClientId from request headers and socket address
@@ -50,6 +65,7 @@ impl WebSocketFsm {
 	pub async fn add_connection(&self, headers: &HeaderMap, addr: &SocketAddr, cancel_token: &CancellationToken) -> Result<String, ConnectionError> {
 		let start = Instant::now();
 		let client_id = self.client_id_from_request(headers, addr);
+		let client_type = client_type_label(&client_id);
 
 		let domain_conn = Connection::new(client_id.clone(), *addr);
 
@@ -61,8 +77,20 @@ impl WebSocketFsm {
 
 		let handle = self.store.insert(client_key.clone(), domain_conn, cancel_token);
 
+		// The entry occupies a store slot from this point regardless of
+		// whether the subscribe below succeeds, so `created`/`connected` are
+		// recorded here rather than after — a subscribe failure that leaves
+		// this entry stranded (see the `?` below: nothing removes it on this
+		// path today) should show up as `connected` growing, not disappear
+		// from the count entirely.
+		instrument::record_created(client_type);
+		instrument::set_connected(self.store.len());
+
 		// Update the actor's subscription state to match
-		handle.subscribe(default_subs).await.map_err(|e| ConnectionError::SubscriptionFailed(e))?;
+		handle.subscribe(default_subs).await.map_err(|e| {
+			instrument::record_error("subscription_failed", "creation");
+			ConnectionError::SubscriptionFailed(e)
+		})?;
 		let elapsed = start.elapsed();
 
 		info!(
@@ -139,6 +167,16 @@ impl WebSocketFsm {
 					cleanup_duration_ms = elapsed.as_millis(),
 					"Connection removed"
 				);
+
+				// `ws_connection_lifecycle_total{event="removed"}` and the
+				// duration histogram are recorded once per socket at
+				// `ConnectionCleanup::drop` (websocket.rs), not here — this
+				// function is called from several places that Drop still
+				// runs after (stale timeout, client close, forwarder end),
+				// and double-instrumenting both would double-count. Only
+				// `connected` — cheap, and this store entry genuinely just
+				// left — is refreshed here for immediacy.
+				instrument::set_connected(self.store.len());
 
 				Ok(())
 			}

--- a/apps/servers/file_host/src/websocket/connection/handlers.rs
+++ b/apps/servers/file_host/src/websocket/connection/handlers.rs
@@ -24,8 +24,15 @@ pub(crate) async fn send_initial_handshake(sender: &mut SplitSink<WebSocket, Mes
 	Ok(())
 }
 
-pub(crate) async fn clear_connection(state: &WebSocketFsm, conn_key: &str) {
+/// Removes a connection that was added to the store but will never get a
+/// `ConnectionCleanup` (`websocket.rs`) — the handshake send failed before
+/// that guard was ever constructed, so nothing else will record its removal.
+/// `client_type` is passed in by the caller (recomputed from the same
+/// headers/addr `add_connection` used) rather than looked up here, since the
+/// store entry is gone by the time this returns.
+pub(crate) async fn clear_connection(state: &WebSocketFsm, conn_key: &str, client_type: &'static str) {
 	let result = state.remove_connection(conn_key, "Connection failed during setup".to_string()).await;
+	super::instrument::record_removed(client_type, "error", 0.0);
 
 	if let Err(e) = result {
 		error!(

--- a/apps/servers/file_host/src/websocket/connection/instrument.rs
+++ b/apps/servers/file_host/src/websocket/connection/instrument.rs
@@ -1,322 +1,131 @@
-use lazy_static::lazy_static;
-use prometheus::{register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, HistogramVec, IntCounterVec, IntGaugeVec};
+//! WebSocket connection metrics, recorded through the `metrics` facade per
+//! [#139][issue-139] (P1) — see #226 (C1) and #227 (C2).
+//!
+//! This file used to declare eight `prometheus` `lazy_static!` families and
+//! eight recording macros, none of which had a call site. Because a
+//! `lazy_static!` registers on first dereference, that meant the families
+//! were never registered at all — not zero, absent — and one macro
+//! (`connection_health_check!`) referenced a module path
+//! (`$crate::connection::instrument`) that doesn't resolve, so it could not
+//! have compiled at any call site either. #226 picked, per family, whether
+//! to wire it at its real call site or delete it:
+//!
+//!   - `ws_connection_lifecycle_total{event}` — kept, `created`/`removed`
+//!     only. `marked_stale`/`disconnected` are gone: nothing in the live
+//!     code path ever drives `ConnectionState` through those transitions
+//!     (`ConnectionCommand::MarkStale`/`Disconnect` have no caller — the
+//!     only "monitor" that would have sent them, `ws-connection`'s
+//!     `core/monitor.rs`, references a `crate::websocket` module tree that
+//!     doesn't exist in this crate and isn't declared in `lib.rs`, so it
+//!     has never compiled into anything). Keeping those event values would
+//!     have meant a counter that reads real but is structurally unable to
+//!     move.
+//!   - `ws_client_connections{client_type}` — kept, paired with lifecycle.
+//!   - `ws_connection_duration_seconds{end_reason}` — kept, recorded once
+//!     per socket at the `ConnectionCleanup::drop` choke point
+//!     (`websocket.rs`) rather than at store-level removal: `Drop` is the
+//!     one place every connection's teardown provably passes through
+//!     exactly once, including the server-shutdown path where the store
+//!     entry is reclaimed directly by `ConnectionStore`'s own cancellation
+//!     handling rather than through `WebSocketFsm::remove_connection`.
+//!   - `ws_connection_messages_total{message_type}` — kept, relabelled onto
+//!     the raw WebSocket frame kind (`text`/`ping`/`pong`/`close`/`binary`)
+//!     recorded in `message/handlers.rs::handle_websocket_message`, the one
+//!     site every inbound frame passes through regardless of payload.
+//!   - `ws_connection_errors_total{error_type,phase}` — kept, wired at the
+//!     real failure points in connection setup and message handling.
+//!   - `ws_connection_states{state}` — deleted. `state="stale"` could never
+//!     move for the same reason `marked_stale` above couldn't: nothing
+//!     drives a connection into `ConnectionState::is_stale`. Superseded by
+//!     `ws_connections{state}` below, which answers the question this
+//!     dashboard row actually needs (connected/live/subscribed) instead of
+//!     a state the code never reaches.
+//!   - `ws_connection_subscriptions{event_type}` — deleted per #226's own
+//!     note that it overlaps with #227's needs. A per-event-type breakdown
+//!     has no reader: the CLIENTS row (#229) asks "does this connection
+//!     want anything", not "which event types are popular".
+//!   - `ws_timeout_monitor_operations_total{operation,result}` — deleted.
+//!     Its `operation` label values (`mark_stale`/`cleanup`/`health_check`)
+//!     describe `ws-connection::core::monitor::TimeoutMonitor`, which — see
+//!     above — is not part of this workspace's compiled graph. There is no
+//!     monitor loop to instrument.
+//!
+//! `ws_connections{state}` (connected/live/subscribed) and the
+//! `ConnectionGuard` occupancy/capacity gauges are #227's new families —
+//! see `websocket.rs::WebSocketFsm::connection_gauges` and
+//! `metrics::periodic` for where they're computed and refreshed.
+//!
+//! [issue-139]: https://github.com/paulgsc/server/issues/139
 
-lazy_static! {
-		// Connection-specific metrics
-		pub static ref CONNECTION_LIFECYCLE: IntCounterVec = register_int_counter_vec!(
-				"ws_connection_lifecycle_total",
-				"Connection lifecycle events",
-				&["event"] // "created", "marked_stale", "disconnected", "removed"
-		).expect("Failed to register CONNECTION_LIFECYCLE");
+use metrics::{counter, gauge, histogram};
 
-		pub static ref CONNECTION_STATES: IntGaugeVec = register_int_gauge_vec!(
-				"ws_connection_states",
-				"Current connection counts by state",
-				&["state"] // "active", "stale"
-		).expect("Failed to register CONNECTION_STATES");
-
-		pub static ref CONNECTION_DURATION: HistogramVec = register_histogram_vec!(
-				"ws_connection_duration_seconds",
-				"Connection lifetime duration",
-				&["end_reason"], // "timeout", "client_disconnect", "error", "cleanup"
-				vec![1.0, 5.0, 30.0, 60.0, 300.0, 600.0, 1800.0, 3600.0]
-		).expect("Failed to register CONNECTION_DURATION");
-
-		pub static ref CLIENT_CONNECTIONS: IntGaugeVec = register_int_gauge_vec!(
-				"ws_client_connections",
-				"Active connections per client",
-				&["client_type"] // "auth", "proxy", "direct"
-		).expect("Failed to register CLIENT_CONNECTIONS");
-
-		pub static ref CONNECTION_MESSAGES: IntCounterVec = register_int_counter_vec!(
-				"ws_connection_messages_total",
-				"Messages processed per connection",
-				&["message_type"] // "ping", "pong", "subscribe", "unsubscribe", "broadcast"
-		).expect("Failed to register CONNECTION_MESSAGES");
-
-		pub static ref TIMEOUT_MONITOR_OPERATIONS: IntCounterVec = register_int_counter_vec!(
-				"ws_timeout_monitor_operations_total",
-				"Timeout monitor operations",
-				&["operation", "result"] // operation: "mark_stale", "cleanup", "health_check"
-		).expect("Failed to register TIMEOUT_MONITOR_OPERATIONS");
-
-		pub static ref CONNECTION_SUBSCRIPTIONS: IntGaugeVec = register_int_gauge_vec!(
-				"ws_connection_subscriptions",
-				"Subscription counts by event type",
-				&["event_type"]
-		).expect("Failed to register CONNECTION_SUBSCRIPTIONS");
-
-		pub static ref CONNECTION_ERRORS: IntCounterVec = register_int_counter_vec!(
-				"ws_connection_errors_total",
-				"Connection-related errors",
-				&["error_type", "phase"] // phase: "creation", "operation", "cleanup"
-		).expect("Failed to register CONNECTION_ERRORS");
+/// A connection was added to the store. Paired with [`record_removed`].
+pub fn record_created(client_type: &'static str) {
+	counter!("ws_connection_lifecycle_total", "event" => "created").increment(1);
+	gauge!("ws_client_connections", "client_type" => client_type).increment(1.0);
 }
 
-/// Records connection creation
-#[macro_export]
-macro_rules! record_connection_created {
-    ($connection_id:expr, $client_id:expr) => {
-        $crate::websocket::connection::instrument::CONNECTION_LIFECYCLE
-            .with_label_values(&["created"])
-            .inc();
-
-        $crate::websocket::connection::instrument::CONNECTION_STATES
-            .with_label_values(&["active"])
-            .inc();
-
-        // Track client type distribution
-        let client_type = if $client_id.as_str().starts_with("auth:") {
-            "auth"
-        } else if $client_id.as_str().starts_with("proxy:") {
-            "proxy"
-        } else {
-            "direct"
-        };
-
-        $crate::websocket::connection::instrument::CLIENT_CONNECTIONS
-            .with_label_values(&[client_type])
-            .inc();
-
-        info!(
-            connection_id = %$connection_id,
-            client_id = %$client_id,
-            client_type = client_type,
-            "Connection created"
-        );
-    };
+/// A connection's socket-level resources (tasks, permit) were torn down —
+/// called exactly once per socket, from `ConnectionCleanup::drop`.
+///
+/// `end_reason` is one of `timeout` | `client_disconnect` | `error` |
+/// `cleanup`, decided by the caller from why the teardown happened, not
+/// inferred here from a free-text reason string the way the deleted macro
+/// did it.
+pub fn record_removed(client_type: &'static str, end_reason: &'static str, duration_secs: f64) {
+	counter!("ws_connection_lifecycle_total", "event" => "removed").increment(1);
+	gauge!("ws_client_connections", "client_type" => client_type).decrement(1.0);
+	histogram!("ws_connection_duration_seconds", "end_reason" => end_reason).record(duration_secs);
 }
 
-/// Records connection state transitions
-#[macro_export]
-macro_rules! record_connection_state_change {
-    ($connection_id:expr, $client_id:expr, $from_state:expr, $to_state:expr) => {
-        match (&$from_state, &$to_state) {
-            (ConnectionState::Active { .. }, ConnectionState::Stale { .. }) => {
-                $crate::websocket::connection::instrument::CONNECTION_LIFECYCLE
-                    .with_label_values(&["marked_stale"])
-                    .inc();
-
-                $crate::websocket::connection::instrument::CONNECTION_STATES
-                    .with_label_values(&["active"])
-                    .dec();
-
-                $crate::websocket::connection::instrument::CONNECTION_STATES
-                    .with_label_values(&["stale"])
-                    .inc();
-
-                info!(
-                    connection_id = %$connection_id,
-                    client_id = %$client_id,
-                    "Connection marked as stale"
-                );
-            },
-            (ConnectionState::Active { .. }, ConnectionState::Disconnected { .. }) => {
-                $crate::websocket::connection::instrument::CONNECTION_LIFECYCLE
-                    .with_label_values(&["disconnected"])
-                    .inc();
-
-                $crate::websocket::connection::instrument::CONNECTION_STATES
-                    .with_label_values(&["active"])
-                    .dec();
-
-                info!(
-                    connection_id = %$connection_id,
-                    client_id = %$client_id,
-                    "Connection disconnected from active state"
-                );
-            },
-            (ConnectionState::Stale { .. }, ConnectionState::Disconnected { .. }) => {
-                $crate::websocket::connection::instrument::CONNECTION_LIFECYCLE
-                    .with_label_values(&["disconnected"])
-                    .inc();
-
-                $crate::websocket::connection::instrument::CONNECTION_STATES
-                    .with_label_values(&["stale"])
-                    .dec();
-
-                info!(
-                    connection_id = %$connection_id,
-                    client_id = %$client_id,
-                    "Connection disconnected from stale state"
-                );
-            },
-            _ => {
-                warn!(
-                    connection_id = %$connection_id,
-                    client_id = %$client_id,
-                    from_state = ?$from_state,
-                    to_state = ?$to_state,
-                    "Unexpected state transition"
-                );
-            }
-        }
-    };
+/// A raw WebSocket frame was processed, labelled by its frame kind
+/// (`text`/`ping`/`pong`/`close`/`binary`) rather than by parsed message
+/// content — see this module's header comment for why.
+pub fn record_message(message_type: &'static str) {
+	counter!("ws_connection_messages_total", "message_type" => message_type).increment(1);
 }
 
-/// Records connection removal with duration tracking
-#[macro_export]
-macro_rules! record_connection_removed {
-    ($connection_id:expr, $client_id:expr, $duration:expr, $reason:expr) => {
-        $crate::websocket::connection::instrument::CONNECTION_LIFECYCLE
-            .with_label_values(&["removed"])
-            .inc();
-
-        // Determine end reason category for histogram
-        let reason_category = if $reason.contains("timeout") || $reason.contains("stale") {
-            "timeout"
-        } else if $reason.contains("closed") || $reason.contains("disconnect") {
-            "client_disconnect"
-        } else if $reason.contains("error") || $reason.contains("failed") {
-            "error"
-        } else {
-            "cleanup"
-        };
-
-        $crate::websocket::connection::instrument::CONNECTION_DURATION
-            .with_label_values(&[reason_category])
-            .observe($duration.as_secs_f64());
-
-        // Update client connection count
-        let client_type = if $client_id.as_str().starts_with("auth:") {
-            "auth"
-        } else if $client_id.as_str().starts_with("proxy:") {
-            "proxy"
-        } else {
-            "direct"
-        };
-
-        $crate::websocket::connection::instrument::CLIENT_CONNECTIONS
-            .with_label_values(&[client_type])
-            .dec();
-
-        info!(
-            connection_id = %$connection_id,
-            client_id = %$client_id,
-            duration_secs = $duration.as_secs(),
-            reason = $reason,
-            reason_category = reason_category,
-            "Connection removed"
-        );
-    };
+/// A connection-related failure, at one of the real failure points in
+/// connection setup (`phase = "creation"`) or message handling
+/// (`phase = "operation"`).
+pub fn record_error(error_type: &'static str, phase: &'static str) {
+	counter!("ws_connection_errors_total", "error_type" => error_type, "phase" => phase).increment(1);
 }
 
-/// Records message processing for a connection
-#[macro_export]
-macro_rules! record_connection_message {
-    ($connection_id:expr, $message_type:expr) => {
-        $crate::websocket::connection::instrument::CONNECTION_MESSAGES
-            .with_label_values(&[$message_type])
-            .inc();
-
-        debug!(
-            connection_id = %$connection_id,
-            message_type = $message_type,
-            "Message processed"
-        );
-    };
+/// `connected` / `live` / `subscribed` — see #227. `connected` is cheap
+/// (a `DashMap::len()`) and is also set synchronously from
+/// `add_connection`/`remove_connection`; `live` and `subscribed` require
+/// awaiting every connection actor and are refreshed only by
+/// `metrics::periodic`'s background sweep, never from the request or scrape
+/// path.
+pub fn set_presence_gauges(connected: usize, live: usize, subscribed: usize) {
+	set_connected(connected);
+	#[allow(clippy::cast_precision_loss)]
+	gauge!("ws_connections", "state" => "live").set(live as f64);
+	#[allow(clippy::cast_precision_loss)]
+	gauge!("ws_connections", "state" => "subscribed").set(subscribed as f64);
 }
 
-/// Records subscription changes
-#[macro_export]
-macro_rules! record_subscription_change {
-    ($connection_id:expr, $operation:expr, $event_types:expr, $changed_count:expr) => {
-        for event_type in $event_types {
-            let event_type_str = format!("{:?}", event_type);
-            match $operation {
-                "subscribe" => {
-                    $crate::websocket::connection::instrument::CONNECTION_SUBSCRIPTIONS
-                        .with_label_values(&[&event_type_str])
-                        .inc();
-                },
-                "unsubscribe" => {
-                    $crate::websocket::connection::instrument::CONNECTION_SUBSCRIPTIONS
-                        .with_label_values(&[&event_type_str])
-                        .dec();
-                },
-                _ => {}
-            }
-        }
-
-        debug!(
-            connection_id = %$connection_id,
-            operation = $operation,
-            changed_count = $changed_count,
-            event_types = ?$event_types,
-            "Subscription change recorded"
-        );
-    };
+/// Just `connected` — cheap enough to call from `add_connection` and
+/// `remove_connection` directly, so it moves within one scrape interval
+/// instead of waiting for the next periodic sweep.
+pub fn set_connected(connected: usize) {
+	#[allow(clippy::cast_precision_loss)]
+	gauge!("ws_connections", "state" => "connected").set(connected as f64);
 }
 
-/// Records timeout monitor operations
-#[macro_export]
-macro_rules! record_timeout_operation {
-	($operation:expr, $result:expr, $count:expr) => {
-		$crate::websocket::connection::instrument::TIMEOUT_MONITOR_OPERATIONS
-			.with_label_values(&[$operation, $result])
-			.inc();
-
-		if $count > 0 {
-			info!(operation = $operation, result = $result, count = $count, "Timeout monitor operation completed");
-		}
-	};
+/// `ConnectionGuard`'s global semaphore occupancy — permits held right now.
+/// Diverging from `connected` (held steady while `connected` drops toward
+/// zero) is the signature of a leaked permit; see #227.
+pub fn set_guard_occupancy(occupancy: usize) {
+	#[allow(clippy::cast_precision_loss)]
+	gauge!("ws_connection_guard_occupancy").set(occupancy as f64);
 }
 
-/// Records connection errors with context
-#[macro_export]
-macro_rules! record_connection_error {
-    ($error_type:expr, $phase:expr, $error:expr) => {
-        $crate::websocket::connection::instrument::CONNECTION_ERRORS
-            .with_label_values(&[$error_type, $phase])
-            .inc();
-
-        error!(
-            error_type = $error_type,
-            phase = $phase,
-            error = %$error,
-            "Connection error recorded"
-        );
-    };
-
-    ($error_type:expr, $phase:expr, $connection_id:expr, $error:expr) => {
-        $crate::websocket::connection::instrument::CONNECTION_ERRORS
-            .with_label_values(&[$error_type, $phase])
-            .inc();
-
-        error!(
-            error_type = $error_type,
-            phase = $phase,
-            connection_id = %$connection_id,
-            error = %$error,
-            "Connection error recorded with context"
-        );
-    };
-}
-
-/// Health check for connection module invariants
-#[macro_export]
-macro_rules! connection_health_check {
-	($connections:expr) => {{
-		let active_count = $connections.iter().filter(|entry| entry.value().is_active()).count();
-
-		let stale_count = $connections.iter().filter(|entry| entry.value().is_stale()).count();
-
-		let total_count = $connections.len();
-
-		// Update current state metrics to ensure accuracy
-		$crate::connection::instrument::CONNECTION_STATES.with_label_values(&["active"]).set(active_count as i64);
-
-		$crate::connection::instrument::CONNECTION_STATES.with_label_values(&["stale"]).set(stale_count as i64);
-
-		// Log health snapshot
-		debug!(
-			total_connections = total_count,
-			active_connections = active_count,
-			stale_connections = stale_count,
-			"Connection health check completed"
-		);
-
-		// Return health data for caller
-		(total_count, active_count, stale_count)
-	}};
+/// `ConnectionGuard`'s configured global capacity (`ws_conn_manager::MAX_GLOBAL`).
+/// Set once at startup, the same "fixed value, dashboarded so it doesn't
+/// have to be memorised" shape as `metrics::build_info::record`.
+pub fn set_guard_capacity(capacity: usize) {
+	#[allow(clippy::cast_precision_loss)]
+	gauge!("ws_connection_guard_capacity").set(capacity as f64);
 }

--- a/apps/servers/file_host/src/websocket/message.rs
+++ b/apps/servers/file_host/src/websocket/message.rs
@@ -1,3 +1,4 @@
+use crate::websocket::connection::instrument;
 use crate::WebSocketFsm;
 use some_transport::{NatsTransport, UnboundedSenderExt};
 use tokio::sync::mpsc::UnboundedSender;
@@ -21,6 +22,7 @@ impl WebSocketFsm {
 					raw_message = %raw_message,
 					"Failed to deserialize websocket JSON message"
 				);
+				instrument::record_error("invalid_json", "operation");
 
 				self.send_error_to_client(ws_tx, &format!("Invalid JSON: {}", e));
 				return;
@@ -58,6 +60,7 @@ impl WebSocketFsm {
 				error = %e,
 				"Failed to subscribe to event types"
 			);
+			instrument::record_error("subscription_update_failed", "operation");
 			self.send_error_to_client(ws_tx, &format!("Subscription failed: {}", e));
 			return;
 		}
@@ -75,6 +78,7 @@ impl WebSocketFsm {
 				error = %e,
 				"Failed to unsubscribe from event types"
 			);
+			instrument::record_error("subscription_update_failed", "operation");
 			self.send_error_to_client(ws_tx, &format!("Unsubscription failed: {}", e));
 			return;
 		}

--- a/apps/servers/file_host/src/websocket/message/handlers.rs
+++ b/apps/servers/file_host/src/websocket/message/handlers.rs
@@ -1,3 +1,4 @@
+use crate::websocket::connection::instrument;
 use crate::WebSocketFsm;
 use axum::extract::ws::{Message, WebSocket};
 use futures::stream::{SplitStream, StreamExt};
@@ -18,11 +19,16 @@ pub(crate) fn spawn_process_incoming_messages(
 	ws_tx: UnboundedSender<Event>,
 	conn_key: String,
 	cancel_token: CancellationToken,
-) -> JoinHandle<u64> {
+) -> JoinHandle<(u64, &'static str)> {
 	tokio::spawn(async move { process_incoming_messages(receiver, state, transport, ws_tx, conn_key, cancel_token).await })
 }
 
-/// Process all incoming messages from the WebSocket
+/// Process all incoming messages from the WebSocket.
+///
+/// Returns `(messages_processed, end_reason)` — `end_reason` is one of
+/// `timeout` | `client_disconnect` | `error` | `cleanup`, the same label set
+/// `ConnectionCleanup::drop` (`websocket.rs`) records under, decided here
+/// because this loop is the one place that actually knows *why* it broke.
 async fn process_incoming_messages(
 	mut receiver: SplitStream<WebSocket>,
 	state: WebSocketFsm,
@@ -30,13 +36,14 @@ async fn process_incoming_messages(
 	ws_tx: UnboundedSender<Event>,
 	conn_key: String,
 	cancel_token: CancellationToken,
-) -> u64 {
+) -> (u64, &'static str) {
 	let mut message_count = 0u64;
 
 	let mut stale_check_interval = interval(Duration::from_secs(30));
-	let stale_timeout = Duration::from_secs(120);
+	let stale_timeout = crate::websocket::STALE_TIMEOUT;
 
 	let store = state.store.clone();
+	let end_reason: &'static str;
 
 	loop {
 		tokio::select! {
@@ -46,6 +53,7 @@ async fn process_incoming_messages(
 					messages_processed = message_count,
 					"WebSocket message processing cancelled - shutting down"
 				);
+				end_reason = "cleanup";
 				break;
 			}
 
@@ -55,6 +63,7 @@ async fn process_incoming_messages(
 						connection_id = %conn_key,
 						"Connection actor missing during stale check - closing"
 					);
+					end_reason = "cleanup";
 					break;
 				};
 
@@ -76,6 +85,7 @@ async fn process_incoming_messages(
 									"Stale connection - no inbound activity".to_string(),
 								)
 								.await;
+							end_reason = "timeout";
 							break;
 						}
 					}
@@ -85,6 +95,8 @@ async fn process_incoming_messages(
 							error = ?e,
 							"Failed to fetch connection state - closing"
 						);
+						instrument::record_error("state_fetch_failed", "operation");
+						end_reason = "error";
 						break;
 					}
 				}
@@ -100,6 +112,7 @@ async fn process_incoming_messages(
 								connection_id = %conn_key,
 								"Connection actor missing on inbound frame"
 							);
+							end_reason = "cleanup";
 							break;
 						};
 
@@ -109,6 +122,8 @@ async fn process_incoming_messages(
 								error = ?e,
 								"Failed to record inbound activity - closing"
 							);
+							instrument::record_error("activity_record_failed", "operation");
+							end_reason = "error";
 							break;
 						}
 
@@ -123,6 +138,7 @@ async fn process_incoming_messages(
 							.await
 								.is_err()
 						{
+							end_reason = "client_disconnect";
 							break;
 						}
 					}
@@ -135,6 +151,8 @@ async fn process_incoming_messages(
 							error = %e,
 							"WebSocket error"
 						);
+						instrument::record_error("stream_error", "operation");
+						end_reason = "error";
 						break;
 					}
 
@@ -143,6 +161,7 @@ async fn process_incoming_messages(
 							connection_id = %conn_key,
 							"WebSocket stream ended"
 						);
+						end_reason = "client_disconnect";
 						break;
 					}
 				}
@@ -150,7 +169,7 @@ async fn process_incoming_messages(
 		}
 	}
 
-	message_count
+	(message_count, end_reason)
 }
 
 /// Handle a single WebSocket message based on its type
@@ -163,16 +182,24 @@ async fn handle_websocket_message(
 ) -> Result<(), ()> {
 	match msg {
 		Message::Text(text) => {
+			instrument::record_message("text");
 			// Process the message
 			state.process_message(transport, ws_tx, conn_key, text).await;
 			Ok(())
 		}
 
-		Message::Ping(_) => Ok(()),
+		Message::Ping(_) => {
+			instrument::record_message("ping");
+			Ok(())
+		}
 
-		Message::Pong(_) => Ok(()),
+		Message::Pong(_) => {
+			instrument::record_message("pong");
+			Ok(())
+		}
 
 		Message::Close(reason) => {
+			instrument::record_message("close");
 			let reason_str = reason
 				.as_ref()
 				.map(|f| format!("{}: {}", f.code, f.reason))
@@ -189,6 +216,9 @@ async fn handle_websocket_message(
 			Err(())
 		}
 
-		Message::Binary(_) => Ok(()),
+		Message::Binary(_) => {
+			instrument::record_message("binary");
+			Ok(())
+		}
 	}
 }

--- a/crates/some-cache/src/metrics.rs
+++ b/crates/some-cache/src/metrics.rs
@@ -43,3 +43,38 @@ pub fn namespace_of(key: &str) -> &str {
 		None => key,
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::namespace_of;
+
+	// #228 (C3): "confirm `namespace_of` produces a bounded label set for
+	// the key patterns actually in use; a key with no `:` becomes its own
+	// namespace." The `cache_hits_total{namespace}` label's cardinality is
+	// bounded by the number of *prefixes* callers use, not by the number of
+	// keys — these are the two ways that could fail to hold.
+
+	#[test]
+	fn collapses_varying_ids_under_the_same_prefix() {
+		// A namespace with a thousand different ids is still one label
+		// value, not a thousand — the whole point of prefix-based namespacing.
+		for id in ["abc123", "def456", "0"] {
+			assert_eq!(namespace_of(&format!("capture:session:{id}")), "capture:session");
+		}
+	}
+
+	#[test]
+	fn single_segment_key_is_its_own_namespace() {
+		// The documented edge case: a key with no ':' at all has no prefix
+		// to collapse onto, so it becomes its own (unbounded-in-principle)
+		// namespace. Callers are responsible for not minting keys shaped
+		// this way at unbounded cardinality — `namespace_of` cannot enforce
+		// a convention its caller didn't follow, only report it faithfully.
+		assert_eq!(namespace_of("simplekey"), "simplekey");
+	}
+
+	#[test]
+	fn two_segment_key_is_the_prefix_alone() {
+		assert_eq!(namespace_of("embed:xyz"), "embed");
+	}
+}

--- a/infra/grafana/dashboards/dashboard.jsonnet
+++ b/infra/grafana/dashboards/dashboard.jsonnet
@@ -2,6 +2,7 @@ local panels = import 'lib/panels.libsonnet';
 local utils = import 'lib/utils.libsonnet';
 local panelDefaults = import 'lib/panel-defaults.libsonnet';
 local health = import 'lib/health-panels.libsonnet';
+local clients = import 'lib/clients-panels.libsonnet';
 
 local dashboard = {
   annotations: {
@@ -62,21 +63,45 @@ local dashboard = {
     health.requestRateByOutcome { gridPos: utils.gridPos(0, 6, 24, 6) },
     health.httpLatencyByRoute { gridPos: utils.gridPos(0, 12, 24, 6) },
 
+    // =============== CLIENTS (#214/#229) ===============
+    // Is anybody there, and is anyone holding a socket for nothing. WS
+    // CONNS/LIVE/SUBSCRIBED are read as a triple — see
+    // clients-panels.libsonnet's header — so they sit adjacent rather than
+    // in separate rows the way HEALTH's independent conditions do.
+    clients.wsConns { gridPos: utils.gridPos(0, 18, 6, 4), id: 910 },
+    clients.live { gridPos: utils.gridPos(6, 18, 6, 4), id: 911 },
+    clients.subscribed { gridPos: utils.gridPos(12, 18, 6, 4), id: 912 },
+    clients.reqPerMin { gridPos: utils.gridPos(18, 18, 6, 4), id: 913 },
+
+    clients.churn { gridPos: utils.gridPos(0, 22, 12, 6), id: 914 },
+    clients.closesByReason { gridPos: utils.gridPos(12, 22, 12, 6), id: 915 },
+
+    clients.cacheHitMissByNamespace { gridPos: utils.gridPos(0, 28, 12, 6), id: 916 },
+    clients.sqlitePool { gridPos: utils.gridPos(12, 28, 12, 6), id: 917 },
+
+    // WS internals — see clients-panels.libsonnet's own comment: readers
+    // for the families #226 kept but that didn't make the epic's own
+    // mock-up, reclaimed from `parked/ws-panels.libsonnet`.
+    clients.guardOccupancy { gridPos: utils.gridPos(0, 34, 12, 6), id: 918 },
+    clients.clientTypeDistribution { gridPos: utils.gridPos(12, 34, 12, 6), id: 919 },
+    clients.messageRate { gridPos: utils.gridPos(0, 40, 12, 6), id: 920 },
+    clients.connectionErrors { gridPos: utils.gridPos(12, 40, 12, 6), id: 921 },
+
     // =============== ROW 1: UPTIME SLA ===============
-    panels.uptimeOverallStatus { gridPos: utils.gridPos(0, 18, 6, 4) },
-    panels.uptimeSLA30d { gridPos: utils.gridPos(6, 18, 6, 4) },
-    panels.tcpConnectivity { gridPos: utils.gridPos(12, 18, 6, 4) },
-    panels.httpWebSocketProbe { gridPos: utils.gridPos(18, 18, 6, 4) },
+    panels.uptimeOverallStatus { gridPos: utils.gridPos(0, 46, 6, 4) },
+    panels.uptimeSLA30d { gridPos: utils.gridPos(6, 46, 6, 4) },
+    panels.tcpConnectivity { gridPos: utils.gridPos(12, 46, 6, 4) },
+    panels.httpWebSocketProbe { gridPos: utils.gridPos(18, 46, 6, 4) },
 
     // =============== ROW 2: UPTIME TRENDS & DIAGNOSTICS ===============
-    panels.uptimeTrend7d { gridPos: utils.gridPos(0, 22, 12, 8) },
-    panels.probeDiagnostics { gridPos: utils.gridPos(12, 22, 12, 8) },
+    panels.uptimeTrend7d { gridPos: utils.gridPos(0, 50, 12, 8) },
+    panels.probeDiagnostics { gridPos: utils.gridPos(12, 50, 12, 8) },
 
     // =============== ROW 3: APPLICATION METRICS ===============
     // The standalone liveness stat this row used to carry (#212/G3) is
     // superseded by the HEALTH row's UP panel above, which is the same
     // `up{job="file_host"}` query — no need for both.
-    panels.operationDuration { gridPos: utils.gridPos(0, 30, 24, 8) },
+    panels.operationDuration { gridPos: utils.gridPos(0, 58, 24, 8) },
   ]),
   refresh: '5s',
   schemaVersion: 38,

--- a/infra/grafana/dashboards/lib/clients-panels.libsonnet
+++ b/infra/grafana/dashboards/lib/clients-panels.libsonnet
@@ -1,0 +1,202 @@
+// clients-panels.libsonnet
+//
+// The CLIENTS row — #214/#229 (C4). "Is anybody there, and is anyone
+// holding a socket for nothing." Second row of the operational dashboard,
+// below HEALTH.
+//
+// WS CONNS / LIVE / SUBSCRIBED are meant to be read together, not each
+// against its own threshold — `3/3/3` is healthy, `3/3/0` is three sockets
+// pooling for nobody, `3/1/3` is two half-open connections not yet reaped.
+// All four stats therefore share one always-green baseline (`harden()`,
+// applied where this is imported into `dashboard.jsonnet`, is what turns a
+// genuinely absent series grey instead) rather than a red ceiling copied
+// from a deployment this one isn't — see #219 and #229's own note that a
+// threshold sized for a public service would never fire here.
+local cachePanels = import 'cache/cache-panels.libsonnet';
+local panelDefaults = import 'panel-defaults.libsonnet';
+
+local alwaysGreen = {
+  mode: 'thresholds',
+  steps: [{ color: 'green', value: null }],
+};
+
+local statFieldConfig(unit) = {
+  defaults: {
+    unit: unit,
+    color: { mode: 'thresholds' },
+    thresholds: alwaysGreen,
+    noValue: 'no data',
+  },
+  overrides: [],
+};
+
+local statOptions = {
+  colorMode: 'value',
+  graphMode: 'none',
+  justifyMode: 'center',
+  orientation: 'horizontal',
+  reduceOptions: { calcs: ['lastNotNull'], values: false },
+  textMode: 'value',
+};
+
+local timeSeriesFieldConfig = {
+  defaults: {
+    custom: { drawStyle: 'line', fillOpacity: 15, lineWidth: 2, pointSize: 4, showPoints: 'never', spanNulls: false, stacking: { mode: 'none' } },
+    color: { mode: 'palette-classic' },
+  },
+  overrides: [],
+};
+
+local timeSeriesOptions = {
+  legend: { showLegend: true, placement: 'bottom' },
+  tooltip: { mode: 'multi', sort: 'desc' },
+};
+
+{
+  // WS CONNS — `connected`, the raw store size. Updated synchronously from
+  // `add_connection`/`remove_connection` (file_host's `websocket.rs`), so
+  // this one moves within a scrape interval; LIVE/SUBSCRIBED move on
+  // `metrics::periodic`'s own cadence (10s) instead — see #227.
+  wsConns: {
+    title: 'WS CONNS',
+    type: 'stat',
+    targets: [{ expr: 'sum(ws_connections{state="connected"})', instant: true, refId: 'A' }],
+    fieldConfig: statFieldConfig('none'),
+    options: statOptions,
+  },
+
+  // LIVE — active, not stale, heard from within `STALE_TIMEOUT`. The same
+  // freshness window the WS message loop itself uses to decide staleness,
+  // so this number and the connections it actually closes agree.
+  live: {
+    title: 'LIVE',
+    type: 'stat',
+    targets: [{ expr: 'sum(ws_connections{state="live"})', instant: true, refId: 'A' }],
+    fieldConfig: statFieldConfig('none'),
+    options: statOptions,
+  },
+
+  // SUBSCRIBED — connections with at least one subscription. `WS CONNS >
+  // SUBSCRIBED`, sustained, is the "sockets pooling for nobody" signature
+  // #227 exists to make visible.
+  subscribed: {
+    title: 'SUBSCRIBED',
+    type: 'stat',
+    targets: [{ expr: 'sum(ws_connections{state="subscribed"})', instant: true, refId: 'A' }],
+    fieldConfig: statFieldConfig('none'),
+    options: statOptions,
+  },
+
+  // REQ/MIN — the HEALTH row already answers "is the server rejecting or
+  // saturated"; this is the plain-language "is anything happening at all"
+  // companion, on the same `http_requests_total` HEALTH already emits.
+  reqPerMin: {
+    title: 'REQ/MIN',
+    type: 'stat',
+    targets: [{ expr: 'sum(rate(http_requests_total[5m])) * 60', instant: true, refId: 'A' }],
+    fieldConfig: statFieldConfig('none') { defaults+: { decimals: 1 } },
+    options: statOptions,
+  },
+
+  // Connection churn — opens/sec against closes/sec. A reconnect storm
+  // shows as both rates rising together while WS CONNS itself stays flat,
+  // which is otherwise close to invisible.
+  churn: {
+    title: 'Connection Churn: Open / Close',
+    type: 'timeseries',
+    targets: [
+      { expr: 'sum(rate(ws_connection_lifecycle_total{event="created"}[5m]))', legendFormat: 'opened', refId: 'A' },
+      { expr: 'sum(rate(ws_connection_lifecycle_total{event="removed"}[5m]))', legendFormat: 'closed', refId: 'B' },
+    ],
+    fieldConfig: timeSeriesFieldConfig { defaults+: { unit: 'ops' } },
+    options: timeSeriesOptions,
+  },
+
+  // Closes by reason — `ws_connection_duration_seconds_count` is the same
+  // histogram #227 records `end_reason` on at the `ConnectionCleanup` seam;
+  // its `_count` series by `end_reason` *is* "why are my connections
+  // disappearing", with no separate counter needed to answer it.
+  closesByReason: {
+    title: 'Closes by Reason',
+    type: 'timeseries',
+    targets: [{ expr: 'sum by (end_reason) (rate(ws_connection_duration_seconds_count[5m]))', legendFormat: '{{end_reason}}', refId: 'A' }],
+    fieldConfig: timeSeriesFieldConfig { defaults+: { unit: 'ops', custom+: { stacking: { mode: 'normal' } } } },
+    options: timeSeriesOptions,
+  },
+
+  // Cache hit/miss by namespace — #228's reader for `cache_hits_total`/
+  // `cache_misses_total`, reused rather than redefined so this panel and
+  // `cache-dashboard.json`'s can't drift onto two different queries for the
+  // same two metrics.
+  cacheHitMissByNamespace: cachePanels.cacheHitsAndMissesByNamespace,
+
+  // SQLite pool: size vs idle — #228. Idle reaching zero while size sits at
+  // the configured max (`main.rs`'s `max_connections(5)`) is pool
+  // exhaustion, visible here *before* the 5s `busy_timeout` turns it into a
+  // user-visible failure.
+  sqlitePool: {
+    title: 'SQLite Pool: Size vs Idle',
+    type: 'timeseries',
+    targets: [
+      { expr: 'sqlite_pool_size', legendFormat: 'size', refId: 'A' },
+      { expr: 'sqlite_pool_idle', legendFormat: 'idle', refId: 'B' },
+    ],
+    fieldConfig: timeSeriesFieldConfig { defaults+: { unit: 'none' } },
+    options: timeSeriesOptions,
+  },
+
+  // --- WS internals ------------------------------------------------------
+  // The four panels below aren't in the epic's own CLIENTS mock-up, but
+  // each is the reader #217's contract check requires for a family #226/
+  // #227 emit — and #229's own task list says to reclaim what survives from
+  // `ws-dashboard.jsonnet` rather than leave those families readerless a
+  // second time. `parked/ws-panels.libsonnet` designed the shapes; these
+  // just point them at the metrics #226 kept.
+
+  // `ConnectionGuard` occupancy vs its configured capacity — #227's
+  // permit-leak assertion made visible: a leaked permit shows as occupancy
+  // that doesn't return to zero even after `connected` does.
+  guardOccupancy: {
+    title: 'Connection Guard: Occupancy vs Capacity',
+    type: 'timeseries',
+    targets: [
+      { expr: 'ws_connection_guard_occupancy', legendFormat: 'occupancy', refId: 'A' },
+      { expr: 'ws_connection_guard_capacity', legendFormat: 'capacity', refId: 'B' },
+    ],
+    fieldConfig: timeSeriesFieldConfig { defaults+: { unit: 'none' } },
+    options: timeSeriesOptions,
+  },
+
+  // Client type distribution — reclaimed from `parked/ws-panels.libsonnet`'s
+  // `wsClientConnections`, pointed at the same `ws_client_connections`
+  // family #226 kept (the `auth`/`proxy`/`direct` bucketing was already the
+  // right granularity; see that story's non-goals).
+  clientTypeDistribution: {
+    title: 'Client Type Distribution',
+    type: 'timeseries',
+    targets: [{ expr: 'ws_client_connections', legendFormat: '{{client_type}}', refId: 'A' }],
+    fieldConfig: timeSeriesFieldConfig { defaults+: { unit: 'none', custom+: { stacking: { mode: 'normal' } } } },
+    options: timeSeriesOptions,
+  },
+
+  // Message rate by raw frame kind — reclaimed from `wsMessageRate`;
+  // `message_type` is now `text`/`ping`/`pong`/`close`/`binary` (#226
+  // relabelled it off the raw WebSocket frame, not parsed event content —
+  // see `instrument.rs`'s header for why).
+  messageRate: {
+    title: 'Message Rate by Frame Kind',
+    type: 'timeseries',
+    targets: [{ expr: 'sum(rate(ws_connection_messages_total[5m])) by (message_type)', legendFormat: '{{message_type}}', refId: 'A' }],
+    fieldConfig: timeSeriesFieldConfig { defaults+: { unit: 'ops' } },
+    options: timeSeriesOptions,
+  },
+
+  // Connection errors by type/phase — reclaimed from `wsErrors`.
+  connectionErrors: {
+    title: 'Connection Errors',
+    type: 'timeseries',
+    targets: [{ expr: 'sum(rate(ws_connection_errors_total[5m])) by (error_type, phase)', legendFormat: '{{error_type}} - {{phase}}', refId: 'A' }],
+    fieldConfig: timeSeriesFieldConfig { defaults+: { unit: 'ops' } },
+    options: timeSeriesOptions,
+  },
+}

--- a/infra/grafana/generated/dashboard.json
+++ b/infra/grafana/generated/dashboard.json
@@ -806,6 +806,670 @@
       "type": "timeseries"
     },
     {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "#8E8E8E",
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "thresholds",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 18
+      },
+      "id": 910,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "sum(ws_connections{state=\"connected\"})",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "WS CONNS",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "#8E8E8E",
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "thresholds",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 18
+      },
+      "id": 911,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "sum(ws_connections{state=\"live\"})",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "LIVE",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "#8E8E8E",
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "thresholds",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 18
+      },
+      "id": 912,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "sum(ws_connections{state=\"subscribed\"})",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "SUBSCRIBED",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "#8E8E8E",
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "thresholds",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 18
+      },
+      "id": 913,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[5m])) * 60",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "REQ/MIN",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 914,
+      "options": {
+        "legend": {
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(ws_connection_lifecycle_total{event=\"created\"}[5m]))",
+          "legendFormat": "opened",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(ws_connection_lifecycle_total{event=\"removed\"}[5m]))",
+          "legendFormat": "closed",
+          "refId": "B"
+        }
+      ],
+      "title": "Connection Churn: Open / Close",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 915,
+      "options": {
+        "legend": {
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (end_reason) (rate(ws_connection_duration_seconds_count[5m]))",
+          "legendFormat": "{{end_reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Closes by Reason",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 916,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(cache_hits_total[5m])) by (namespace)",
+          "legendFormat": "{{namespace}} - hit"
+        },
+        {
+          "expr": "sum(rate(cache_misses_total[5m])) by (namespace)",
+          "legendFormat": "{{namespace}} - miss"
+        }
+      ],
+      "title": "Hits vs Misses by Namespace",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 917,
+      "options": {
+        "legend": {
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sqlite_pool_size",
+          "legendFormat": "size",
+          "refId": "A"
+        },
+        {
+          "expr": "sqlite_pool_idle",
+          "legendFormat": "idle",
+          "refId": "B"
+        }
+      ],
+      "title": "SQLite Pool: Size vs Idle",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "id": 918,
+      "options": {
+        "legend": {
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "ws_connection_guard_occupancy",
+          "legendFormat": "occupancy",
+          "refId": "A"
+        },
+        {
+          "expr": "ws_connection_guard_capacity",
+          "legendFormat": "capacity",
+          "refId": "B"
+        }
+      ],
+      "title": "Connection Guard: Occupancy vs Capacity",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "id": 919,
+      "options": {
+        "legend": {
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "ws_client_connections",
+          "legendFormat": "{{client_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Client Type Distribution",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 920,
+      "options": {
+        "legend": {
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(ws_connection_messages_total[5m])) by (message_type)",
+          "legendFormat": "{{message_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Message Rate by Frame Kind",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 921,
+      "options": {
+        "legend": {
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(ws_connection_errors_total[5m])) by (error_type, phase)",
+          "legendFormat": "{{error_type}} - {{phase}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Connection Errors",
+      "type": "timeseries"
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -848,7 +1512,7 @@
         "h": 4,
         "w": 6,
         "x": 0,
-        "y": 18
+        "y": 46
       },
       "id": 1,
       "options": {
@@ -931,7 +1595,7 @@
         "h": 4,
         "w": 6,
         "x": 6,
-        "y": 18
+        "y": 46
       },
       "id": 2,
       "options": {
@@ -1005,7 +1669,7 @@
         "h": 4,
         "w": 6,
         "x": 12,
-        "y": 18
+        "y": 46
       },
       "id": 4,
       "options": {
@@ -1074,7 +1738,7 @@
         "h": 4,
         "w": 6,
         "x": 18,
-        "y": 18
+        "y": 46
       },
       "id": 5,
       "options": {
@@ -1141,7 +1805,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 22
+        "y": 50
       },
       "id": 3,
       "options": {
@@ -1205,7 +1869,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 22
+        "y": 50
       },
       "id": 6,
       "options": {
@@ -1283,7 +1947,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 58
       },
       "id": 9,
       "options": {


### PR DESCRIPTION
## Description

Lands the [CLIENTS] epic (#214): *is anybody there, and is anyone holding a socket for nothing.*

**C1 (#226)** — `websocket/connection/instrument.rs` declared eight Prometheus `lazy_static!` metric families with zero call sites; one macro (`connection_health_check!`) referenced a module path that doesn't resolve and could never have compiled anywhere. Converted the survivors onto the `metrics` facade #139 chose and wired each at its real call site (`connection.rs`'s `add_connection`, `message/handlers.rs`, `message.rs`, and the `ConnectionCleanup::drop` seam in `websocket.rs`). Deleted `ws_connection_states`/`ws_connection_subscriptions` (superseded by C2's `ws_connections` gauge) and `ws_timeout_monitor_operations_total` (its would-be caller, `ws-connection`'s `core/monitor.rs`, isn't declared in that crate's `lib.rs` and has never compiled into anything — confirmed with a grep before deleting it, not assumed).

**C2 (#227)** — `connected`/`live`/`subscribed` gauges, derived from the existing `ConnectionStore` rather than parallel bookkeeping (`WebSocketFsm::connection_gauges`, with `live_connection_count` now a thin wrapper so `nudge::presence`'s call site is untouched). `connected` updates synchronously on add/remove (cheap, no await); `live`/`subscribed` and `ConnectionGuard` occupancy refresh on a periodic 10s background sweep (`metrics::periodic`), off the request/scrape path. Close reason (`timeout`/`client_disconnect`/`error`/`cleanup`) is recorded once per socket at the `ConnectionCleanup` `Drop` choke point — the one place every connection's teardown provably passes through exactly once, including the server-shutdown path that bypasses `remove_connection` entirely.

**C3 (#228)** — SQLite pool `size`/`idle` gauges from the shared pool (`metrics/pool.rs`), refreshed on the same periodic sweep: idle hitting zero while size sits at the configured max (`max_connections(5)`) is now visible before the 5s `busy_timeout` turns it into a user-visible failure. `some-cache`'s four metric families were already on the `metrics` facade from #139's work — confirmed they have a dashboard reader rather than re-wiring what wasn't broken; added a small `namespace_of` bounding test.

**C4 (#229)** — the CLIENTS row on the operational dashboard: WS CONNS / LIVE / SUBSCRIBED / REQ-MIN as an always-green stat quad meant to be read together (a threshold sized for a public service would never fire on this deployment), connection churn, closes-by-reason, cache hit/miss by namespace, and the SQLite pool gauges. Also reclaimed panel designs from `dashboards/parked/ws-panels.libsonnet` for the families C1 kept but that didn't make the epic's own mock-up (client type distribution, message rate, connection guard occupancy vs. capacity, connection errors), so every emitted WS metric has a reader — #217's contract check (`scripts/check_metric_contract.py`) passes with zero exemptions needed.

Also removed the now-unused `prometheus`/`protobuf` crates from `file_host`'s dependency graph and the workspace manifest.

Closes #226
Closes #227
Closes #228
Closes #229
Closes #214

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- `cargo check --workspace` and `cargo test --workspace` — clean, all suites passing (`file_host`'s lib tests, `some-cache`, `ws-connection`, `ws-conn-manager`, etc.)
- New unit test (`websocket::tests::opening_and_closing_a_connection_moves_the_lifecycle_counters`) exercises `add_connection`/`remove_connection`/`ConnectionCleanup::drop` against a `metrics_util::debugging::DebuggingRecorder` and asserts the lifecycle counters, `connected` gauge, and duration histogram actually moved — C1's own acceptance criterion.
- New unit tests for `some-cache`'s `namespace_of` bounding behavior.
- `python3 scripts/check_metric_contract.py` — `metric contract OK: 25 emitted metrics, 84 queried metrics, 14 active dashboard sources.`
- `jsonnet -J lib dashboard.jsonnet` (and all other active dashboards) build cleanly; checked for panel `id` collisions and `gridPos` overlaps in the regenerated JSON — none found.
- `cargo fmt --all -- --check` — no new diffs introduced (the handful of pre-existing diffs on `main` are unrelated files/toolchain nightly-feature warnings, verified via `git stash`).

**Test Configuration**:
* Toolchain: stable Rust (workspace pin), `DATABASE_URL` against a locally migrated SQLite db for `sqlx::query!` offline-mode verification
* SDK: n/a

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Scope note on C3: the epic's task list also mentions "count query outcomes at the repository seam — ok/error." That would mean touching six separate repository crates' full CRUD surface with no dashboard panel ready to read the result. Given C3's acceptance criteria don't require it and the SQLite pool gauges already satisfy the pool-exhaustion criterion, this PR ships the pool gauges and leaves repository-level outcome counters for a follow-up story rather than adding emitted-but-unread metrics.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NagozNPMB1EPQsuRfLvtXN)_