### PR TITLE
feat(nudge): expose waker liveness metrics and derive LOOPS threshold from live interval

### DIFF
--- a/apps/servers/file_host/src/metrics.rs
+++ b/apps/servers/file_host/src/metrics.rs
@@ -11,6 +11,7 @@ pub mod periodic;
 pub mod pool;
 pub mod rate_limit;
 pub mod refusals;
+pub mod waker;
 
 #[allow(unused_imports)]
 pub use observability::{ObservabilityError, OtelGuard};

--- a/apps/servers/file_host/src/metrics/waker.rs
+++ b/apps/servers/file_host/src/metrics/waker.rs
@@ -1,0 +1,20 @@
+//! Liveness metrics for the engagement waker (#216/P4, #236).
+//!
+//! A successful pass can legitimately find no due work and emit no domain
+//! events.  These gauges make that quiet success distinguishable from a task
+//! which stopped running.  The interval is exported too: the dashboard must
+//! compare the pass age with the deployment's actual configuration rather
+//! than with the default compiled into `Config`.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Publish the configured interval as soon as the task is spawned.
+pub fn record_interval(interval: Duration) {
+	metrics::gauge!("nudge_waker_interval_seconds").set(interval.as_secs_f64());
+}
+
+/// Mark a completed, successful pass, including an empty one.
+pub fn record_successful_pass() {
+	let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0.0, |elapsed| elapsed.as_secs_f64());
+	metrics::gauge!("nudge_waker_last_pass_timestamp_seconds").set(timestamp);
+}

--- a/apps/servers/file_host/src/nudge/waker.rs
+++ b/apps/servers/file_host/src/nudge/waker.rs
@@ -44,9 +44,12 @@ const BATCH: i64 = 32;
 /// Spawn the waker, cancelled through the shared token.
 pub fn spawn(state: AppState, interval: Duration) {
 	let cancel = state.core.cancel_token.clone();
+	crate::metrics::waker::record_interval(interval);
 
 	tokio::spawn(async move {
 		info!(interval_secs = interval.as_secs(), "engagement waker started");
+		let mut ticker = tokio::time::interval(interval);
+		ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
 		loop {
 			tokio::select! {
@@ -54,9 +57,10 @@ pub fn spawn(state: AppState, interval: Duration) {
 					info!("engagement waker cancelled");
 					return;
 				}
-				() = tokio::time::sleep(interval) => {
-					if let Err(err) = run_once(&state).await {
-						error!(error = %err, "waker pass failed");
+				_ = ticker.tick() => {
+					match run_once(&state).await {
+						Ok(_) => crate::metrics::waker::record_successful_pass(),
+						Err(err) => error!(error = %err, "waker pass failed"),
 					}
 				}
 			}

--- a/infra/grafana/dashboards/lib/health-panels.libsonnet
+++ b/infra/grafana/dashboards/lib/health-panels.libsonnet
@@ -8,18 +8,9 @@ local panelDefaults = import 'panel-defaults.libsonnet';
 
 local docsUrl = 'https://github.com/paulgsc/server/blob/main/docs/fault-conditions.md';
 
-// #236 ([PUSH] P4, a sibling epic) has not landed yet — nothing in this
-// workspace emits `nudge_waker_last_pass_timestamp_seconds`, which the
-// LOOPS/SIGNAL panels below query anyway: #219's rule is exactly built for
-// this, a query against an as-yet-unemitted metric renders grey (unknown),
-// never green, so the panel is honest on day one and starts reporting real
-// data the moment #236 lands with no dashboard change required.
-// scripts/check_metric_contract.py carries the matching EXEMPT_QUERIED
-// entry with this same reason. LOOPS' `900` threshold is 3x
-// `nudge_waker_seconds`' own default (config.rs) — #236's own task list
-// promises a `nudge_waker_interval_seconds` gauge so this can derive from
-// live configuration instead; until it lands, 3x the *default* interval is
-// the best static approximation available.
+// #216/P4 (#236) exports both the most recent successful pass and the live
+// configured interval. An empty pass counts as successful: quiet success and
+// a stopped task are precisely the two states this signal must separate.
 
 local docLink(anchor) = [
   {
@@ -96,22 +87,15 @@ local docLink(anchor) = [
     options: { colorMode: 'value', graphMode: 'none', justifyMode: 'center', orientation: 'horizontal', reduceOptions: { calcs: ['lastNotNull'], values: false }, textMode: 'value' },
   },
 
-  // LOOPS — condition #5 (stalled). See `waker_last_pass`/`stalledAfterSeconds`
-  // above for why this queries a metric #236 hasn't landed yet, and why the
-  // threshold is a static stand-in for that story's own configured-interval
-  // gauge.
+  // LOOPS — condition #5 (stalled). Three missed configured intervals is a
+  // fault; deriving the threshold from the exported interval keeps a tuned
+  // deployment honest.
   loops: {
     title: 'LOOPS',
     type: 'stat',
     id: 904,
     links: docLink('stalled'),
-    // #217's contract check (scripts/check_metric_contract.py) reads
-    // `expr:` literally out of this file, the same way it reads every other
-    // panel library — jsonnet's `%` string interpolation would hide the
-    // literal metric name from it, so this is written out directly rather
-    // than built from `waker_last_pass`/`stalledAfterSeconds` above (which
-    // exist to document *why*, not to be interpolated from).
-    targets: [{ expr: '(time() - nudge_waker_last_pass_timestamp_seconds) > bool 900', instant: true, refId: 'A' }],
+    targets: [{ expr: '(time() - nudge_waker_last_pass_timestamp_seconds) > bool (3 * nudge_waker_interval_seconds)', instant: true, refId: 'A' }],
     fieldConfig: {
       defaults: {
         unit: 'none',
@@ -148,6 +132,7 @@ local docLink(anchor) = [
           or sum(absent(http_requests_total))
           or sum(absent(refusals_total))
           or sum(absent(nudge_waker_last_pass_timestamp_seconds))
+          or sum(absent(nudge_waker_interval_seconds))
         ) or vector(0)
       |||,
       instant: true,

--- a/infra/grafana/generated/dashboard.json
+++ b/infra/grafana/generated/dashboard.json
@@ -427,7 +427,7 @@
       },
       "targets": [
         {
-          "expr": "(time() - nudge_waker_last_pass_timestamp_seconds) > bool 900",
+          "expr": "(time() - nudge_waker_last_pass_timestamp_seconds) > bool (3 * nudge_waker_interval_seconds)",
           "instant": true,
           "refId": "A"
         }
@@ -509,7 +509,7 @@
       },
       "targets": [
         {
-          "expr": "(\n  sum(absent(up{job=\"file_host\"}))\n  or sum(absent(dependency_up))\n  or sum(absent(http_requests_total))\n  or sum(absent(refusals_total))\n  or sum(absent(nudge_waker_last_pass_timestamp_seconds))\n) or vector(0)\n",
+          "expr": "(\n  sum(absent(up{job=\"file_host\"}))\n  or sum(absent(dependency_up))\n  or sum(absent(http_requests_total))\n  or sum(absent(refusals_total))\n  or sum(absent(nudge_waker_last_pass_timestamp_seconds))\n  or sum(absent(nudge_waker_interval_seconds))\n) or vector(0)\n",
           "instant": true,
           "refId": "A"
         }
@@ -574,7 +574,7 @@
         {
           "expr": "service_info",
           "instant": true,
-          "legendFormat": "{{git_sha}} · rustc {{rust}} · built {{built_at}}",
+          "legendFormat": "{{git_sha}} \u00b7 rustc {{rust}} \u00b7 built {{built_at}}",
           "refId": "A"
         }
       ],
@@ -1833,7 +1833,7 @@
                 },
                 "1": {
                   "color": "red",
-                  "text": "FIRING — limiter not enforcing"
+                  "text": "FIRING \u2014 limiter not enforcing"
                 }
               },
               "type": "value"
@@ -1890,7 +1890,7 @@
           "refId": "A"
         }
       ],
-      "title": "INVARIANT: Traffic Above Limit ∧ Zero Rejections",
+      "title": "INVARIANT: Traffic Above Limit \u2227 Zero Rejections",
       "type": "stat"
     },
     {
@@ -1964,7 +1964,7 @@
           "refId": "A"
         }
       ],
-      "title": "✅ Overall Uptime Status",
+      "title": "\u2705 Overall Uptime Status",
       "type": "stat"
     },
     {
@@ -2004,11 +2004,11 @@
               },
               {
                 "color": "yellow",
-                "value": 99.900000000000006
+                "value": 99.9
               },
               {
                 "color": "green",
-                "value": 99.950000000000003
+                "value": 99.95
               }
             ]
           },
@@ -2047,7 +2047,7 @@
           "refId": "A"
         }
       ],
-      "title": "🎯 30-Day Uptime SLA",
+      "title": "\ud83c\udfaf 30-Day Uptime SLA",
       "type": "stat"
     },
     {
@@ -2116,7 +2116,7 @@
           "refId": "A"
         }
       ],
-      "title": "🔌 TCP Connectivity (Port 3000)",
+      "title": "\ud83d\udd0c TCP Connectivity (Port 3000)",
       "type": "stat"
     },
     {
@@ -2185,7 +2185,7 @@
           "refId": "A"
         }
       ],
-      "title": "💬 HTTP /ws Probe (101/429/503)",
+      "title": "\ud83d\udcac HTTP /ws Probe (101/429/503)",
       "type": "stat"
     },
     {
@@ -2218,7 +2218,7 @@
               },
               {
                 "color": "red",
-                "value": 99.900000000000006
+                "value": 99.9
               }
             ]
           },
@@ -2254,7 +2254,7 @@
           "refId": "A"
         }
       ],
-      "title": "📈 7-Day Uptime Trend",
+      "title": "\ud83d\udcc8 7-Day Uptime Trend",
       "type": "timeseries"
     },
     {
@@ -2327,7 +2327,7 @@
           "refId": "D"
         }
       ],
-      "title": "🔍 Probe Diagnostics (Duration & Failures)",
+      "title": "\ud83d\udd0d Probe Diagnostics (Duration & Failures)",
       "type": "timeseries"
     },
     {
@@ -2391,7 +2391,7 @@
           "refId": "A"
         }
       ],
-      "title": "⚙️ Operation Duration (P95)",
+      "title": "\u2699\ufe0f Operation Duration (P95)",
       "type": "timeseries"
     }
   ],
@@ -2413,7 +2413,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "🩺 file_host Operational Dashboard",
+  "title": "\ud83e\ude7a file_host Operational Dashboard",
   "uid": "file-host-dashboard",
   "version": 1
 }

--- a/scripts/check_metric_contract.py
+++ b/scripts/check_metric_contract.py
@@ -63,7 +63,6 @@ EXEMPT_QUERIED_PREFIXES: dict[str, str] = {
 EXEMPT_QUERIED_EXACT: dict[str, str] = {
 	"up": "Prometheus's own per-target scrape-health series",
 	"ALERTS": "Prometheus's own built-in firing-alerts series",
-	"nudge_waker_last_pass_timestamp_seconds": "owned by #236 ([PUSH] P4), not yet landed — the HEALTH row's LOOPS/SIGNAL panels (#213/#225) query it ahead of the emitter on purpose, per #219's rule that an absent series renders grey rather than green",
 }
 
 # Metrics this workspace emits through the `metrics` facade with no


### PR DESCRIPTION
### Motivation

- Make the engagement waker's health observable so a quiet successful pass (no due work) is distinguishable from the task having stopped. 
- Keep the HEALTH dashboard's stalled-loop threshold honest by deriving it from the waker's configured interval instead of a hardcoded default. 
- Remove a temporary metric-contract exemption now that the waker metrics have a real emitter.

### Description

- Add a new metrics module `apps/servers/file_host/src/metrics/waker.rs` that exports `nudge_waker_interval_seconds` and `nudge_waker_last_pass_timestamp_seconds` and helpers `record_interval`/`record_successful_pass` to publish them. 
- Update the waker `spawn` to publish the configured interval on start, use a Tokio `interval` with delayed missed-tick behavior, run periodic passes, and stamp a success timestamp only after a successful `run_once` completes; this lives in `apps/servers/file_host/src/nudge/waker.rs`. 
- Update the HEALTH dashboard library to derive the LOOPS (stalled) panel threshold from the live `nudge_waker_interval_seconds` and to consider absence of either waker metric as a blind state; changes in `infra/grafana/dashboards/lib/health-panels.libsonnet` and the generated dashboard JSON were updated accordingly. 
- Remove the temporary exemption for the waker metric from `scripts/check_metric_contract.py` so the metric-contract check now treats the waker metrics as emitted/read. 
- Closes #216, #233, #234, #235, #236.

### Testing

- Ran `python scripts/check_metric_contract.py`, which reported the metric contract OK for the workspace (passed). 
- Ran `cargo fmt --all` to normalize formatting (succeeded). 
- Attempted dashboard build and `jsonnet`-based generation in this environment but `jsonnet`/libsonnet tooling was not available here (dashboard build step could not run end-to-end). 
- Started `cargo test -p file_host --lib` compilation for `file_host` but the full test run could not complete within this environment's execution window (compilation progress observed, not fully completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77b1492f10832bb27c6e0b1c40b9c9)