### PR TITLE
ci: gate Docker publishes behind changeset PR

### DIFF
--- a/.github/actions/docker-push/action.yml
+++ b/.github/actions/docker-push/action.yml
@@ -42,7 +42,7 @@ runs:
         push: true
         tags: |
           ${{ inputs.docker-repo }}:latest
-          ${{ inputs.docker-repo }}:${{ github.sha }}
+          ${{ inputs.docker-repo }}:${{ inputs.vcs-ref }}
         build-args: |
           VCS_REF=${{ inputs.vcs-ref }}
           BUILD_DATE=${{ inputs.build-date }}

--- a/.github/scripts/detect/src/main.rs
+++ b/.github/scripts/detect/src/main.rs
@@ -125,7 +125,12 @@ fn is_under_dir(file: &Path, dir: &Path) -> bool {
 
 /// Check whether a changed file affects the image build/publish pipeline.
 fn is_build_pipeline_file(file: &Path, workspace_root: &Path) -> bool {
-	const PIPELINE_FILES: &[&str] = &[".github/workflows/detect.yml", ".github/workflows/build-image.yml", ".github/workflows/push-image.yml"];
+	const PIPELINE_FILES: &[&str] = &[
+		".github/workflows/detect.yml",
+		".github/workflows/build-image.yml",
+		".github/workflows/push-image.yml",
+		".github/workflows/publish-image-changesets.yml",
+	];
 	const PIPELINE_DIRS: &[&str] = &[".github/actions/docker-build", ".github/actions/docker-push", ".github/scripts/detect"];
 
 	PIPELINE_FILES.iter().map(|path| normalize_path(Path::new(path), workspace_root)).any(|path| file == path)

--- a/.github/workflows/detect.yml
+++ b/.github/workflows/detect.yml
@@ -6,11 +6,12 @@ on:
     branches: [main]
   workflow_dispatch:
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # Every main push must reach the staging job; otherwise a newer push could
+  # cancel an older one before its changeset has been added to the release PR.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   detect:
     runs-on: ubuntu-latest
@@ -71,9 +72,23 @@ jobs:
     needs: [detect, build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.detect.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Restore pending changesets
+        env:
+          CHANGESET_BRANCH: automation/docker-image-changesets
+        run: |
+          if git ls-remote --exit-code --heads origin "$CHANGESET_BRANCH" >/dev/null; then
+            git fetch origin "$CHANGESET_BRANCH:refs/remotes/origin/$CHANGESET_BRANCH"
+            git checkout "refs/remotes/origin/$CHANGESET_BRANCH" -- \
+              .github/docker-changesets
+          fi
       - name: Record image changeset
         env:
           MATRIX: ${{ needs.detect.outputs.matrix }}

--- a/.github/workflows/detect.yml
+++ b/.github/workflows/detect.yml
@@ -1,10 +1,13 @@
-name: Detect, Build & Push
+name: Detect, Build & Stage
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -64,10 +67,29 @@ jobs:
     uses: ./.github/workflows/build-image.yml
     with:
       matrix: ${{ needs.detect.outputs.matrix }}
-  push:
+  stage:
     needs: [detect, build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.detect.outputs.has_changes == 'true'
-    uses: ./.github/workflows/push-image.yml
-    secrets: inherit
-    with:
-      matrix: ${{ needs.detect.outputs.matrix }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Record image changeset
+        env:
+          MATRIX: ${{ needs.detect.outputs.matrix }}
+        run: |
+          mkdir -p .github/docker-changesets
+          jq --arg source_sha "${{ github.sha }}" \
+            '{source_sha: $source_sha, include: .include}' \
+            <<< "$MATRIX" > ".github/docker-changesets/${{ github.sha }}.json"
+      - name: Create or update Docker image changeset pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/docker-image-changesets
+          delete-branch: true
+          commit-message: "chore(docker): stage image changesets"
+          title: "chore(docker): publish pending image changes"
+          body: |
+            Merging this pull request publishes the accumulated Docker image changes to Docker Hub.
+
+            This pull request is maintained automatically as image-affecting changes land on `main`.

--- a/.github/workflows/publish-image-changesets.yml
+++ b/.github/workflows/publish-image-changesets.yml
@@ -36,9 +36,38 @@ jobs:
             exit 0
           fi
 
+          # The filenames are commit hashes, so their lexical order does not
+          # describe which image specification is newest. Order the files by
+          # their source commits in main's history and reject any source that
+          # is not part of the commit being published.
+          declare -A CHANGESET_BY_SOURCE
+          for changeset in "${CHANGESETS[@]}"; do
+            source_sha=$(jq -er '.source_sha' "$changeset")
+            if ! git merge-base --is-ancestor "$source_sha" "${{ github.sha }}"; then
+              echo "::error file=$changeset::Changeset source $source_sha is not an ancestor of ${{ github.sha }}"
+              exit 1
+            fi
+            CHANGESET_BY_SOURCE["$source_sha"]=$changeset
+          done
+
+          ORDERED_CHANGESETS=()
+          while read -r source_sha; do
+            if [[ -n "${CHANGESET_BY_SOURCE[$source_sha]+present}" ]]; then
+              ORDERED_CHANGESETS+=("${CHANGESET_BY_SOURCE[$source_sha]}")
+              unset 'CHANGESET_BY_SOURCE[$source_sha]'
+            fi
+          done < <(git rev-list --reverse --topo-order "${{ github.sha }}")
+
+          if (( ${#CHANGESET_BY_SOURCE[@]} != 0 )); then
+            echo '::error::Could not order every Docker image changeset by source commit'
+            exit 1
+          fi
+
           MATRIX=$(jq -c -s \
-            '{include: (map(.include[]) | unique_by(.name))}' \
-            "${CHANGESETS[@]}")
+            'map(. as $changeset | $changeset.include[] + {source_sha: $changeset.source_sha})
+             | reduce .[] as $image ({}; .[$image.name] = $image)
+             | {include: [.[]]}' \
+            "${ORDERED_CHANGESETS[@]}")
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           echo 'has_changes=true' >> "$GITHUB_OUTPUT"
   publish:

--- a/.github/workflows/publish-image-changesets.yml
+++ b/.github/workflows/publish-image-changesets.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
     paths:
       - ".github/docker-changesets/*.json"
+permissions:
+  contents: read
 concurrency:
   group: publish-image-changesets
   cancel-in-progress: false

--- a/.github/workflows/publish-image-changesets.yml
+++ b/.github/workflows/publish-image-changesets.yml
@@ -1,0 +1,48 @@
+name: Publish Image Changesets
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/docker-changesets/*.json"
+concurrency:
+  group: publish-image-changesets
+  cancel-in-progress: false
+jobs:
+  changesets:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.collect.outputs.matrix }}
+      has_changes: ${{ steps.collect.outputs.has_changes }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Collect newly merged changesets
+        id: collect
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          mapfile -t CHANGESETS < <(
+            git diff --diff-filter=A --name-only "$BEFORE" "${{ github.sha }}" -- \
+              '.github/docker-changesets/*.json'
+          )
+
+          if (( ${#CHANGESETS[@]} == 0 )); then
+            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            echo 'has_changes=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          MATRIX=$(jq -c -s \
+            '{include: (map(.include[]) | unique_by(.name))}' \
+            "${CHANGESETS[@]}")
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo 'has_changes=true' >> "$GITHUB_OUTPUT"
+  publish:
+    needs: changesets
+    if: needs.changesets.outputs.has_changes == 'true'
+    uses: ./.github/workflows/push-image.yml
+    secrets: inherit
+    with:
+      matrix: ${{ needs.changesets.outputs.matrix }}

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.source_sha }}
       - name: Compute build date
         id: build_date
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
@@ -35,5 +37,5 @@ jobs:
           docker-repo: pgathondu/${{ matrix.repo_suffix }}
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
-          vcs-ref: ${{ github.sha }}
+          vcs-ref: ${{ matrix.source_sha }}
           build-date: ${{ steps.build_date.outputs.value }}


### PR DESCRIPTION
### Motivation

- Stop automatically pushing images to Docker Hub on every `main` push and instead require an explicit merge action via a consolidated "changeset" PR to make image publishing imperative.

### Description

- Change the detect workflow (`.github/workflows/detect.yml`) to stage image matrices as immutable JSON files under `.github/docker-changesets/` and create or update a single automation PR that accumulates image changes instead of directly pushing images.
- Add a new workflow (`.github/workflows/publish-image-changesets.yml`) that triggers on newly-merged changeset files, aggregates and deduplicates the included images into a single matrix, and invokes the existing image push workflow to publish to Docker Hub.
- Update the detector binary source (`.github/scripts/detect/src/main.rs`) to treat the new `publish-image-changesets.yml` workflow as part of the build/publish pipeline so changes to the publishing flow still force rebuilds/staging.
- Ensure the staged changeset contains the `source_sha` and the image `include` list so the PR represents an immutable record of what to publish when merged.

### Testing

- `git diff --check` passed with no whitespace errors.
- Parsed all workflow YAMLs with `ruby -e 'require "yaml"; ...'` and parsing succeeded for the new workflow file.
- `cargo fmt --manifest-path .github/scripts/detect/Cargo.toml -- --check` completed (noting toolchain warnings about unstable config options but no format failures).
- A local `jq` aggregation smoke test of multiple changeset JSONs produced the expected deduplicated matrix output (command using `jq -c -s ...` succeeded).
- `cargo test --manifest-path .github/scripts/detect/Cargo.toml` could not complete due to network fetch failures in the execution environment (crate download `403`), so Rust crate tests were not run to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81ecc87ee8832b99fcfe9739aab94b)