### PR TITLE
P0.1 · [RCM0] A nudge that needs no session

### DIFF
--- a/apps/servers/file_host/src/nudge/payload.rs
+++ b/apps/servers/file_host/src/nudge/payload.rs
@@ -60,9 +60,13 @@ impl NudgePayload {
 			StudyAction::ResumeAbandoned { .. } => ("Pick up where you left off", "You started something and didn't finish."),
 			StudyAction::SuggestReview { .. } => ("A quick review might help", "Some of the last set didn't stick."),
 			StudyAction::NewMaterial { .. } => ("There's something new", "New material is waiting for you."),
+			StudyAction::GetStarted => ("Let's get started", "Come study something — pick anything to begin."),
 		};
 
-		Self::for_session(base_url, action.session_id(), title.to_owned(), body.to_owned())
+		match action.session_id() {
+			Some(session_id) => Self::for_session(base_url, session_id, title.to_owned(), body.to_owned()),
+			None => Self::for_base(base_url, title.to_owned(), body.to_owned()),
+		}
 	}
 
 	/// Build the payload for a session deep link.
@@ -72,13 +76,35 @@ impl NudgePayload {
 	/// different one lands the click on the dashboard instead of the session.
 	#[must_use]
 	pub fn for_session(base_url: &str, session_id: &str, title: String, body: String) -> Self {
-		let base = if base_url.ends_with('/') { base_url.to_owned() } else { format!("{base_url}/") };
-
 		Self {
 			title,
 			body,
-			url: format!("{base}sessions/{session_id}"),
+			url: format!("{}sessions/{session_id}", Self::normalize_base(base_url)),
 			tag: NUDGE_TAG.to_owned(),
+		}
+	}
+
+	/// Build the payload for the app base itself, with nothing to deep-link
+	/// into yet.
+	///
+	/// [`StudyAction::GetStarted`]'s case: there is no session to open, so the
+	/// honest destination is wherever the app lands someone with nothing
+	/// prepared, not a fabricated session URL — the defect PR #251 shipped.
+	#[must_use]
+	pub fn for_base(base_url: &str, title: String, body: String) -> Self {
+		Self {
+			title,
+			body,
+			url: Self::normalize_base(base_url),
+			tag: NUDGE_TAG.to_owned(),
+		}
+	}
+
+	fn normalize_base(base_url: &str) -> String {
+		if base_url.ends_with('/') {
+			base_url.to_owned()
+		} else {
+			format!("{base_url}/")
 		}
 	}
 
@@ -122,7 +148,11 @@ impl std::error::Error for PayloadError {}
 #[must_use]
 pub const fn topic_for(action: &StudyAction) -> Topic {
 	match action {
-		StudyAction::LessonReady { .. } => Topic::LessonReady,
+		// Closest existing grant: someone who consented to "your lesson is
+		// ready" has consented to being told to start one. `GetStarted` is
+		// interim and retires once #279 lands, which does not warrant a
+		// fifth topic for a message this short-lived.
+		StudyAction::LessonReady { .. } | StudyAction::GetStarted => Topic::LessonReady,
 		StudyAction::ResumeAbandoned { .. } | StudyAction::SuggestReview { .. } => Topic::Coaching,
 		StudyAction::NewMaterial { .. } => Topic::NewMaterial,
 	}
@@ -130,7 +160,21 @@ pub const fn topic_for(action: &StudyAction) -> Topic {
 
 #[cfg(test)]
 mod tests {
-	use super::{NudgePayload, NUDGE_TAG};
+	use super::{topic_for, NudgePayload, NUDGE_TAG};
+	use push_repo::Topic;
+	use study_domain::StudyAction;
+
+	#[test]
+	fn get_started_resolves_to_the_app_base_not_a_session() {
+		let payload = NudgePayload::for_action("https://nixos.local:5173/", &StudyAction::GetStarted);
+		assert_eq!(payload.url, "https://nixos.local:5173/");
+		assert!(!payload.url.contains("/sessions/"), "got {}", payload.url);
+	}
+
+	#[test]
+	fn get_started_borrows_the_lesson_ready_grant() {
+		assert_eq!(topic_for(&StudyAction::GetStarted), Topic::LessonReady);
+	}
 
 	#[test]
 	fn the_deep_link_matches_the_shape_the_client_builds() {

--- a/apps/servers/file_host/src/nudge/waker.rs
+++ b/apps/servers/file_host/src/nudge/waker.rs
@@ -134,9 +134,22 @@ async fn consider(db: &SqlitePool, ws: &WebSocketFsm, nudge: &NudgeContext, enga
 	let consented_topics: Vec<Topic> = Topic::ALL.iter().copied().filter(|topic| subscriptions.iter().any(|sub| sub.accepts(*topic))).collect();
 
 	// What is prepared and untouched. Without one there is nothing to point at,
-	// and the selector returns `None` rather than inventing a reminder that
-	// opens nothing.
-	let sessions = SessionRepository::new(db.clone()).list().await.unwrap_or_default();
+	// and the selector returns `None` (or, for plain absence, `GetStarted`)
+	// rather than inventing a reminder that opens nothing. A failed read is
+	// deliberately *not* defaulted to empty: since `GetStarted` now fires on
+	// exactly that emptiness, silently swallowing the error here would be
+	// indistinguishable from a genuinely empty catalogue and could invite
+	// someone who already has a session waiting. Logged and skipped instead —
+	// `SessionRepoError` doesn't convert to this function's `sqlx::Error`, and
+	// widening the signature is a bigger change than a rare read failure
+	// warrants.
+	let sessions = match SessionRepository::new(db.clone()).list().await {
+		Ok(sessions) => sessions,
+		Err(err) => {
+			error!(subject = %subject_id, error = %err, "could not read sessions; skipping this subject rather than guessing whether one is prepared");
+			return Ok(false);
+		}
+	};
 	let prepared_session = sessions
 		.iter()
 		.find(|session| matches!(session.status, SessionStatus::Scheduled | SessionStatus::Paused | SessionStatus::Draft))

--- a/apps/servers/file_host/src/nudge/waker.rs
+++ b/apps/servers/file_host/src/nudge/waker.rs
@@ -173,8 +173,12 @@ async fn consider(db: &SqlitePool, ws: &WebSocketFsm, nudge: &NudgeContext, enga
 			return Ok(false);
 		}
 		Verdict::NothingToSay => {
-			// Depleted, admissible, and no action fits — which almost always
-			// means nothing is prepared. A gap in the domain, worth saying so.
+			// Depleted, admissible, and no action fits. Plain absence — the
+			// one deficit with a sessionless answer — now gets `GetStarted`
+			// even with nothing prepared, so reaching this arm means the
+			// dominant deficit is Momentum, Mastery, or Freshness with
+			// nothing to resume, review, or announce. A gap in the domain,
+			// worth saying so.
 			warn!(subject = %subject_id, "engagement is low but there is nothing to point them at");
 			let retry = now + chrono::Duration::hours(6);
 			let (levels, as_of) = charge.to_storage();

--- a/crates/study_domain/src/calibration.rs
+++ b/crates/study_domain/src/calibration.rs
@@ -87,15 +87,23 @@ pub struct StudySelector {
 
 impl Selector<StudyV1> for StudySelector {
 	fn select(&self, deficits: &[Deficit<EngagementClass>]) -> Option<StudyAction> {
-		let session_id = self.prepared_session.clone()?;
 		let dominant = deficits.first()?.class;
 
-		Some(match dominant {
-			EngagementClass::Momentum => StudyAction::ResumeAbandoned { session_id },
-			EngagementClass::Mastery => StudyAction::SuggestReview { session_id },
-			EngagementClass::Freshness => StudyAction::NewMaterial { session_id },
-			EngagementClass::Presence => StudyAction::LessonReady { session_id },
-		})
+		match &self.prepared_session {
+			Some(session_id) => Some(match dominant {
+				EngagementClass::Momentum => StudyAction::ResumeAbandoned { session_id: session_id.clone() },
+				EngagementClass::Mastery => StudyAction::SuggestReview { session_id: session_id.clone() },
+				EngagementClass::Freshness => StudyAction::NewMaterial { session_id: session_id.clone() },
+				EngagementClass::Presence => StudyAction::LessonReady { session_id: session_id.clone() },
+			}),
+			// Plain absence is the one deficit with an honest sessionless
+			// answer. The other three cannot resume a session that was never
+			// started, review material that was never studied, or announce
+			// new material to someone who has seen none — silence is still
+			// the honest answer for them.
+			None if dominant == EngagementClass::Presence => Some(StudyAction::GetStarted),
+			None => None,
+		}
 	}
 }
 
@@ -188,10 +196,51 @@ mod tests {
 	}
 
 	#[test]
-	fn with_nothing_prepared_there_is_nothing_to_say() {
+	fn with_nothing_prepared_three_of_four_deficits_stay_silent() {
+		// Still holds for Momentum, Mastery, and Freshness: none of them has
+		// anything to point at without a prepared session. Presence is the
+		// exception — see the next test.
+		let now = Utc.with_ymd_and_hms(2026, 8, 5, 12, 0, 0).unwrap();
+		let empty = StudySelector { prepared_session: None };
+
+		let mut abandoned = Charge::<StudyV1>::full::<StudyCalibration>(now);
+		abandoned.apply::<StudyCalibration>(
+			&StudySignal::SessionAbandoned {
+				session_id: "session-1".to_owned(),
+				elapsed_ms: 25 * 60_000,
+			},
+			now,
+		);
+		assert!(empty.select(&abandoned.deficits::<StudyCalibration>(now)).is_none());
+
+		let mut poorly_scored = Charge::<StudyV1>::full::<StudyCalibration>(now);
+		for _ in 0..3 {
+			poorly_scored.apply::<StudyCalibration>(
+				&StudySignal::ScoredBelowTarget {
+					activity_id: "a".to_owned(),
+					score: 0.1,
+				},
+				now,
+			);
+		}
+		assert!(empty.select(&poorly_scored.deficits::<StudyCalibration>(now)).is_none());
+
+		let mut stale = Charge::<StudyV1>::full::<StudyCalibration>(now);
+		stale.apply::<StudyCalibration>(&StudySignal::CurriculumUpdated { curriculum_id: "c".to_owned() }, now);
+		assert!(empty.select(&stale.deficits::<StudyCalibration>(now)).is_none());
+	}
+
+	#[test]
+	fn with_nothing_prepared_plain_absence_still_invites_getting_started() {
+		// The fourth deficit has an honest sessionless answer. This is #294's
+		// whole change: `Presence` no longer goes silent just because nothing
+		// is prepared yet.
 		let now = Utc.with_ymd_and_hms(2026, 8, 5, 12, 0, 0).unwrap();
 		let charge = Charge::<StudyV1>::full::<StudyCalibration>(now);
+		let later = now + Duration::days(9);
 		let empty = StudySelector { prepared_session: None };
-		assert!(empty.select(&charge.deficits::<StudyCalibration>(now)).is_none());
+
+		let action = empty.select(&charge.deficits::<StudyCalibration>(later)).unwrap();
+		assert!(matches!(action, StudyAction::GetStarted), "got {action:?}");
 	}
 }

--- a/crates/study_domain/src/signal.rs
+++ b/crates/study_domain/src/signal.rs
@@ -171,6 +171,12 @@ pub enum StudyAction {
 	SuggestReview { session_id: String },
 	/// New material they have not seen.
 	NewMaterial { session_id: String },
+	/// Nobody has a session prepared yet, and the recommender that would
+	/// prepare one (`#279`–`#284`) does not exist. Plain absence is the one
+	/// deficit with an honest sessionless answer: come and start something.
+	/// It invites; it does not propose, and it carries no session id because
+	/// there is nothing to point at. Interim — see `docs/study-nudge.md`.
+	GetStarted,
 }
 
 impl StudyAction {
@@ -181,13 +187,37 @@ impl StudyAction {
 			Self::ResumeAbandoned { .. } => "resume-abandoned",
 			Self::SuggestReview { .. } => "suggest-review",
 			Self::NewMaterial { .. } => "new-material",
+			Self::GetStarted => "get-started",
 		}
 	}
 
+	/// The session this action points at, if it points at one.
+	///
+	/// Total until `GetStarted`: every earlier variant carried an id that
+	/// already existed. Two other shapes were considered and rejected, so
+	/// `#279` — which weighs this same cost — can inherit the decision rather
+	/// than re-litigate it:
+	///
+	/// - A separate `has_session()` guard beside an unchanged `-> &str`
+	///   keeps the signature but reintroduces the exact partiality-by-
+	///   convention this change removes: nothing stops a caller from calling
+	///   `session_id()` on `GetStarted` anyway.
+	/// - A split enum — `GetStarted` pulled out of `StudyAction` into a
+	///   wrapping type — keeps every other accessor total, but duplicates
+	///   `kind()` and the serde tag, and forces `payload::topic_for`,
+	///   `NudgePayload::for_action`, and every future match to handle two
+	///   enums instead of one. `GetStarted` is documented to *become* this
+	///   enum's fallback arm once `#279` lands, which only stays cheap if it
+	///   is a variant here rather than a case bolted on beside it.
+	///
+	/// `Option<&str>` is the shape that survives: total, and it costs callers
+	/// nothing they were not already going to need once a variant existed
+	/// without a session.
 	#[must_use]
-	pub fn session_id(&self) -> &str {
+	pub fn session_id(&self) -> Option<&str> {
 		match self {
-			Self::LessonReady { session_id } | Self::ResumeAbandoned { session_id } | Self::SuggestReview { session_id } | Self::NewMaterial { session_id } => session_id,
+			Self::LessonReady { session_id } | Self::ResumeAbandoned { session_id } | Self::SuggestReview { session_id } | Self::NewMaterial { session_id } => Some(session_id),
+			Self::GetStarted => None,
 		}
 	}
 }

--- a/docs/study-nudge.md
+++ b/docs/study-nudge.md
@@ -87,6 +87,25 @@ action:
 | Mastery | `SuggestReview` |
 | Freshness | `NewMaterial` |
 
+### Cold start: the one deficit with a sessionless answer
+
+Three of the four actions above need a prepared session — you cannot resume a
+session that was never started, review material that was never studied, or
+announce new material to someone who has seen none. Before the recommender
+exists (`#279`–`#284`), nothing is ever prepared, so those three stay silent
+exactly as the table implies: `StudySelector::select` returns `None` and the
+engine reaches `Verdict::NothingToSay`.
+
+Plain absence is different: it has an honest sessionless answer. When
+`prepared_session` is `None` and the dominant deficit is `Presence`, the
+selector returns `StudyAction::GetStarted` instead of staying silent — an
+invitation, deep-linking to the app base rather than a session that does not
+exist. This is a deliberately **interim** answer, not the recommender: it
+invites, it does not propose, and it does not provision anything (the
+mistake PR #251 made). `#279` starts replacing it with real proposals, and
+once `#285` lands, `GetStarted` either retires or becomes the documented
+fallback for an empty catalogue.
+
 ## Consent is a precondition, not a preference
 
 **The null case is silence.** There is no path through `push_repo` that creates a


### PR DESCRIPTION
## Description

Fixes #294. Serves the cold-start user before the recommender (`#279`–`#284`) exists, per the landing order in #295 (P0.1, no prerequisites).

`StudySelector::select` now returns `StudyAction::GetStarted` when `prepared_session` is `None` **and** the dominant deficit is `Presence`. Momentum, Mastery, and Freshness still return `None` with nothing prepared — you cannot resume a session that was never started, review material that was never studied, or announce new material to someone who has seen none. Plain absence is the one deficit with an honest sessionless answer.

**The structural cost, decided here for `#279` to inherit:** `StudyAction::session_id()` changes from `-> &str` to `-> Option<&str>`, since `GetStarted` carries no session id. Two other shapes were considered and rejected — a separate `has_session()` guard, and a split enum — with the reasoning recorded on the accessor's doc comment in `crates/study_domain/src/signal.rs`.

`topic_for(GetStarted)` borrows `Topic::LessonReady` — the closest existing grant: someone who consented to "your lesson is ready" has consented to being told to start one. It does not warrant a fifth topic for a message this short-lived.

`NudgePayload` gains `for_base()` so `GetStarted` resolves to the app base rather than a fabricated `/sessions/{id}` URL — the exact defect PR #251 shipped (a `SessionRecord` with `activities: []`, deep-linking to nothing). `GetStarted` invites; it provisions nothing.

`docs/study-nudge.md` records this as a deliberately interim answer, naming `#279` as its replacement.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## How Has This Been Tested?

- `cargo test -p study_domain -p file_host` — 15 + 23 tests pass, including:
  - `with_nothing_prepared_plain_absence_still_invites_getting_started` — asserts `GetStarted` when `Presence` is dominant with nothing prepared.
  - `with_nothing_prepared_three_of_four_deficits_stay_silent` — the amended version of the old "nothing to say" test, now naming which three still hold.
  - `get_started_resolves_to_the_app_base_not_a_session` — asserts the payload URL does not contain `/sessions/`.
  - `get_started_borrows_the_lesson_ready_grant` — asserts `topic_for`.
- `cargo check -p file_host` and `cargo fmt --all -- --check` on the touched files — clean.

**Test Configuration**:
* Toolchain: stable, via `cargo check`/`cargo test` against a migrated SQLite database (per `docs/study-nudge.md`'s setup steps)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Notes

Out of scope, per #294: provisioning anything, choosing activities/durations/composing a session (`#280`–`#282`), and changing `StudyCalibration`. The end-to-end acceptance criterion ("fresh database, one subscription, no sessions, no signals, clock advanced ⇒ exactly one accepted notification") composes with `#278` (P0.2, first-contact gate row), which has not landed yet — this PR covers `#294`'s half of that scenario in isolation; the composed check lands with `#278`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JGhxSTALhuLDL5JTtZ5GEf)_