### PR TITLE
P0.2 · [RCM1] First contact establishes a gate row, so silence #1 stops being permanent

### DIFF
--- a/apps/servers/file_host/src/handlers/push.rs
+++ b/apps/servers/file_host/src/handlers/push.rs
@@ -100,8 +100,18 @@ pub async fn subscribe(State(state): State<AppState>, subject: SubjectId, Json(r
 		consented_at: now.clone(),
 	};
 
-	PushSubscriptionRepository::new(state.core.shared_db)
+	PushSubscriptionRepository::new(state.core.shared_db.clone())
 		.upsert(&request.subscription, &consent, &now)
+		.await
+		.map_err(|err| FileHostError::OperationError(err.to_string()))?;
+
+	// First contact: this is the event that says a subject exists at all —
+	// see `waker::first_contact` for why this route, and not a signal, is the
+	// honest place to seed the gate row. Propagated rather than swallowed:
+	// hiding this failure would silently recreate the exact "never due" bug
+	// (#278) this call exists to close, and the whole call is idempotent, so a
+	// client retry after a `500` is harmless.
+	crate::nudge::waker::first_contact(&state.core.shared_db, subject.as_str())
 		.await
 		.map_err(|err| FileHostError::OperationError(err.to_string()))?;
 

--- a/apps/servers/file_host/src/main.rs
+++ b/apps/servers/file_host/src/main.rs
@@ -174,6 +174,13 @@ async fn main() -> Result<()> {
 	// the resolution at which decided work is picked up, not a cadence at which
 	// anything is decided. See `nudge::waker`.
 	if app_state.nudge.is_some() && config.nudge_enabled {
+		// One-time reconciliation: a subscription recorded before #278 landed
+		// has no reason to be re-sent, so without this pass it would never
+		// reach `engagement_gate` at all. See `waker::backfill_first_contact`.
+		match nudge::waker::backfill_first_contact(&app_state.core.shared_db).await {
+			Ok(seeded) => tracing::info!(seeded, "first-contact backfill complete"),
+			Err(err) => tracing::error!(error = %err, "first-contact backfill failed; existing subscribers may stay ungated until next boot"),
+		}
 		nudge::waker::spawn(&app_state, Duration::from_secs(config.nudge_waker_seconds.max(30)));
 	} else {
 		tracing::info!("engagement waker is not running; /api/v1/push and /api/v1/signals still work");

--- a/apps/servers/file_host/src/nudge/waker.rs
+++ b/apps/servers/file_host/src/nudge/waker.rs
@@ -335,9 +335,12 @@ pub async fn observe(db: &SqlitePool, subject_id: &str, signal: &study_domain::S
 /// subject who already has a row, whether from a prior signal or from a
 /// previous device subscribing.
 ///
+/// Returns whether this call actually seeded the row, so [`backfill_first_contact`]
+/// can report how much of its reconciliation pass was real work.
+///
 /// # Errors
 /// Propagates any storage failure.
-pub async fn first_contact(db: &SqlitePool, subject_id: &str) -> Result<(), sqlx::Error> {
+pub async fn first_contact(db: &SqlitePool, subject_id: &str) -> Result<bool, sqlx::Error> {
 	let engagement = EngagementRepository::new(db.clone());
 	let now = Utc::now();
 
@@ -351,7 +354,48 @@ pub async fn first_contact(db: &SqlitePool, subject_id: &str) -> Result<(), sqlx
 		debug!(subject = %subject_id, eligible_at = %eligible_at, "first contact: gate row seeded full");
 	}
 
-	Ok(())
+	Ok(created)
+}
+
+/// Reconcile pre-existing subscriptions against `engagement_gate`, once, at
+/// boot.
+///
+/// `first_contact` only runs on a live `POST /push/subscriptions` call, and a
+/// browser that already holds a subscription from before this landed has no
+/// reason to send it again — the Push API does not re-announce an unchanged
+/// subscription on its own. Without this pass, every subject who subscribed
+/// before this release stays exactly the silence #1 victim this feature
+/// exists to fix: a `push_subscriptions` row with no path into
+/// `engagement_gate`, forever, unless they happen to unsubscribe and
+/// resubscribe.
+///
+/// Run once at startup rather than folded into the waker's per-tick loop: this
+/// is a one-time reconciliation against rows that predate the fix, not
+/// ongoing work, and `first_contact`'s own idempotency makes repeating it on
+/// every restart a cheap no-op rather than a hazard.
+///
+/// # Errors
+/// Propagates a failure to read `push_subscriptions` itself. A failure to
+/// seed one particular subject is logged and skipped rather than aborting the
+/// pass — one bad row must not leave everyone else ungated, and the next boot
+/// tries again.
+pub async fn backfill_first_contact(db: &SqlitePool) -> Result<usize, sqlx::Error> {
+	let subject_ids = PushSubscriptionRepository::new(db.clone()).distinct_subject_ids().await?;
+
+	let mut seeded = 0;
+	for subject_id in subject_ids {
+		match first_contact(db, &subject_id).await {
+			Ok(true) => seeded += 1,
+			Ok(false) => {}
+			Err(err) => error!(subject = %subject_id, error = %err, "could not backfill a gate row for an existing subscription; will retry next boot"),
+		}
+	}
+
+	if seeded > 0 {
+		info!(seeded, "backfilled gate rows for subscriptions that predate first contact");
+	}
+
+	Ok(seeded)
 }
 
 #[cfg(test)]

--- a/apps/servers/file_host/src/nudge/waker.rs
+++ b/apps/servers/file_host/src/nudge/waker.rs
@@ -310,3 +310,89 @@ pub async fn observe(db: &SqlitePool, subject_id: &str, signal: &study_domain::S
 	debug!(subject = %subject_id, signal = signal.kind(), eligible_at = %eligible_at, "signal folded in");
 	Ok(eligible_at)
 }
+
+/// First contact: give a subject who has never been observed a gate row,
+/// seeded full, so `due` can eventually find them without a signal ever
+/// having arrived.
+///
+/// Before this, the chain was: no session created ⇒ no signal ⇒ no gate row
+/// ⇒ never in `due` ⇒ never nudged. Not late — never. The only caller is
+/// `POST /push/subscriptions`: it is a person explicitly saying "you may
+/// interrupt me", the strongest statement of intent this deployment has, and
+/// (unlike a page load, which is too broad, or a dedicated "hello" route,
+/// which would just re-say what this one already implies) it happens exactly
+/// once per device before any study behaviour exists. The alternative of
+/// seeding lazily when the waker runs is not available at all: the waker can
+/// only see rows that already exist, which is the circularity this function
+/// closes.
+///
+/// Seeded **full**, by the same `Charge::full`/`eligible_at` arithmetic
+/// `observe` falls back to for an unseen subject — see the comment there.
+/// Starting empty would make a brand-new account instantly eligible; someone
+/// who installs the app at 9am must not be interrupted at 9:05.
+///
+/// Idempotent: [`EngagementRepository::seed_if_absent`] is a no-op for a
+/// subject who already has a row, whether from a prior signal or from a
+/// previous device subscribing.
+///
+/// # Errors
+/// Propagates any storage failure.
+pub async fn first_contact(db: &SqlitePool, subject_id: &str) -> Result<(), sqlx::Error> {
+	let engagement = EngagementRepository::new(db.clone());
+	let now = Utc::now();
+
+	let charge = Charge::<StudyV1>::full::<StudyCalibration>(now);
+	let eligible_at = charge.eligible_at::<StudyCalibration>(now);
+	let (levels, as_of) = charge.to_storage();
+
+	let created = engagement.seed_if_absent(subject_id, &levels, &as_of.to_rfc3339(), &eligible_at.to_rfc3339()).await?;
+
+	if created {
+		debug!(subject = %subject_id, eligible_at = %eligible_at, "first contact: gate row seeded full");
+	}
+
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::nudge::clock::NudgeClock;
+	use crate::nudge::constraints::{StudyConstraints, Suppressed};
+	use crate::nudge::presence::Presence;
+	use chrono::{Duration, TimeZone as _};
+
+	fn t0() -> chrono::DateTime<Utc> {
+		Utc.with_ymd_and_hms(2026, 8, 5, 12, 0, 0).unwrap()
+	}
+
+	/// #278's named edge case: someone subscribes, then unsubscribes every
+	/// device before ever becoming due. `actuate` already degrades correctly
+	/// once admission fails; the risk the issue calls out is landing in
+	/// `Verdict::NothingToSay` instead, which `consider` logs at `warn!` on
+	/// every pass. Presence — fastest half-life, highest weight — stays the
+	/// dominant deficit for a subject who has never received a single signal,
+	/// so `GetStarted` (#294) keeps firing and the engine explains the silence
+	/// as `NotConsented` at `info!` rather than falling through to a warn loop.
+	#[test]
+	fn a_first_contact_subject_who_unsubscribed_everywhere_is_suppressed_not_stuck_with_nothing_to_say() {
+		let charge = Charge::<StudyV1>::full::<StudyCalibration>(t0());
+		let far_future = t0() + Duration::days(365);
+
+		let constraints = StudyConstraints {
+			clock: NudgeClock::resolve(Some("UTC")).0,
+			enabled: true,
+			quiet_hours_start: 22,
+			quiet_hours_end: 8,
+			presence: Presence { connected: 0, live: 0 },
+			consented_topics: Vec::new(),
+		};
+		let engine = Engine::<StudyV1, StudyCalibration, _, _>::new(constraints, StudySelector { prepared_session: None });
+
+		let verdict = engine.evaluate(&charge, far_future, None);
+		assert!(
+			matches!(verdict, Verdict::Suppressed { reason: Suppressed::NotConsented, .. }),
+			"got {verdict:?}, expected NotConsented suppression rather than NothingToSay"
+		);
+	}
+}

--- a/crates/db/engagement/src/repository.rs
+++ b/crates/db/engagement/src/repository.rs
@@ -91,6 +91,58 @@ impl EngagementRepository {
 		tx.commit().await
 	}
 
+	/// Give a subject nobody has yet observed a gate row, seeded full.
+	///
+	/// The only caller is first contact (`waker::first_contact`, from
+	/// `POST /push/subscriptions`) — see that function for why subscribing is
+	/// the honest "someone exists" event. This is deliberately **not** built on
+	/// [`Self::save`]: `save`'s `ON CONFLICT` upserts both tables
+	/// unconditionally, which is exactly right for folding in a new signal and
+	/// exactly wrong here — subscribing a second device, or re-subscribing the
+	/// same one, must not reset an already-drifting subject back to full.
+	///
+	/// `INSERT OR IGNORE` against `engagement_gate`'s primary key is the guard,
+	/// not a read-then-write: two devices racing to be the first ever
+	/// subscription for a subject cannot both win, so the charge rows are only
+	/// ever written by whichever transaction's gate insert actually landed.
+	/// Returns whether this call was the one that created the row, so the
+	/// caller can log without a second read.
+	///
+	/// # Errors
+	/// Propagates any `sqlx` failure.
+	pub async fn seed_if_absent(&self, subject_id: &str, levels: &[(u16, f64)], as_of: &str, eligible_at: &str) -> Result<bool, sqlx::Error> {
+		let mut tx = self.pool.begin().await?;
+
+		let inserted = sqlx::query!(
+			r#"INSERT OR IGNORE INTO engagement_gate (subject_id, eligible_at, intervention_count) VALUES (?, ?, 0)"#,
+			subject_id,
+			eligible_at,
+		)
+		.execute(&mut *tx)
+		.await?;
+
+		if inserted.rows_affected() == 0 {
+			tx.rollback().await?;
+			return Ok(false);
+		}
+
+		for (class, level) in levels {
+			let class = i64::from(*class);
+			sqlx::query!(
+				r#"INSERT OR IGNORE INTO engagement_charge (subject_id, class, level, as_of) VALUES (?, ?, ?, ?)"#,
+				subject_id,
+				class,
+				level,
+				as_of,
+			)
+			.execute(&mut *tx)
+			.await?;
+		}
+
+		tx.commit().await?;
+		Ok(true)
+	}
+
 	/// # Errors
 	/// Propagates any `sqlx` failure.
 	pub async fn gate(&self, subject_id: &str) -> Result<Option<GateRow>, sqlx::Error> {

--- a/crates/db/push/src/repository/subscription.rs
+++ b/crates/db/push/src/repository/subscription.rs
@@ -198,6 +198,19 @@ impl PushSubscriptionRepository {
 		Ok(rows.into_iter().map(Into::into).collect())
 	}
 
+	/// Every subject who has ever subscribed, deduplicated.
+	///
+	/// The one caller is the first-contact backfill run at startup —
+	/// reconciling subscriptions that predate `waker::first_contact` against
+	/// `engagement_gate`. [`Self::for_subject`] is not reusable here: this asks
+	/// for the distinct *owners*, not one owner's devices.
+	///
+	/// # Errors
+	/// Propagates any `sqlx` failure.
+	pub async fn distinct_subject_ids(&self) -> Result<Vec<String>, sqlx::Error> {
+		sqlx::query_scalar!("SELECT DISTINCT subject_id FROM push_subscriptions").fetch_all(&self.pool).await
+	}
+
 	/// Remove a subscription. Idempotent: an explicit opt-out and a `410 Gone`
 	/// are saying the same thing, and neither is an error when it has already
 	/// happened.

--- a/crates/study_domain/src/calibration.rs
+++ b/crates/study_domain/src/calibration.rs
@@ -231,6 +231,41 @@ mod tests {
 	}
 
 	#[test]
+	fn first_contact_seeds_full_so_a_brand_new_subject_is_not_instantly_eligible() {
+		// The constraint `waker::observe`'s comment states, which #278's first
+		// contact must preserve exactly: "No rows means never seen, and
+		// `from_storage` starts such a subject full rather than empty — an
+		// empty charge is instantly eligible, so the alternative would nudge a
+		// brand-new account before it did anything." `Charge::full` is that
+		// seed, and this pins it against the real `StudyCalibration` numbers
+		// rather than the toy calibration `intervention`'s own tests use.
+		let now = Utc.with_ymd_and_hms(2026, 8, 5, 12, 0, 0).unwrap();
+		let charge = Charge::<StudyV1>::full::<StudyCalibration>(now);
+		assert!(
+			charge.eligible_at::<StudyCalibration>(now) > now,
+			"a subject seeded at first contact must not be instantly nudgeable"
+		);
+	}
+
+	#[test]
+	fn first_contact_does_become_eligible_once_the_full_charge_decays_to_threshold() {
+		// The expected instant is `eligible_at`'s own solved crossing, not a
+		// hardcoded guess like "a week" — bisection already proves elsewhere
+		// that it lands on the threshold; this pins that same property for
+		// the specific charge first contact writes.
+		let now = Utc.with_ymd_and_hms(2026, 8, 5, 12, 0, 0).unwrap();
+		let charge = Charge::<StudyV1>::full::<StudyCalibration>(now);
+		let eligible = charge.eligible_at::<StudyCalibration>(now);
+
+		assert!(eligible < now + Duration::days(30), "must resolve to a real crossing, not the search horizon");
+		assert!(charge.aggregate::<StudyCalibration>(eligible) <= StudyCalibration::THRESHOLD);
+		assert!(
+			charge.aggregate::<StudyCalibration>(eligible - Duration::seconds(1)) > StudyCalibration::THRESHOLD,
+			"eligible must be the first such instant, not merely one that qualifies"
+		);
+	}
+
+	#[test]
 	fn with_nothing_prepared_plain_absence_still_invites_getting_started() {
 		// The fourth deficit has an honest sessionless answer. This is #294's
 		// whole change: `Presence` no longer goes silent just because nothing

--- a/docs/study-nudge.md
+++ b/docs/study-nudge.md
@@ -106,6 +106,50 @@ mistake PR #251 made). `#279` starts replacing it with real proposals, and
 once `#285` lands, `GetStarted` either retires or becomes the documented
 fallback for an empty catalogue.
 
+### First contact: how a subject enters the gate at all
+
+Until `#278`, nothing did. The waker's entire query is `WHERE eligible_at <=
+now`, and `engagement_gate` rows were created in exactly one place —
+`waker::observe`, called from `POST /signals` — whose only caller is the
+client's session-mutation layer, fired when a session is *created*. The chain
+was: no session ⇒ no signal ⇒ no gate row ⇒ never in `due` ⇒ never nudged.
+Not late. Never. This is silence #1 in `#257`'s cold-start argument, and it
+was silent for exactly the person who most needed the nudge: someone who had
+just installed the app and done nothing else yet.
+
+`POST /push/subscriptions` closes it. `waker::first_contact` runs on every
+call, after the subscription itself is stored: it is a person explicitly
+saying "you may interrupt me" — the strongest statement of intent this
+deployment has — and, unlike a page load (too broad to count as consent) or a
+dedicated "hello" route (a new endpoint restating what this one already
+implies), it happens exactly once per device before any study behaviour
+exists at all. Seeding lazily when the waker runs was never on the table: the
+waker can only see rows that already exist, which is the circularity this
+closes.
+
+The row is written **full**, by the same `Charge::full`/`eligible_at`
+arithmetic `observe` already falls back to for an unseen subject — so a
+first-contact subject and a subject discovered through a stray signal land on
+identical footing, and `eligible_at` comes out on the order of a week later
+rather than five minutes. Idempotent by construction: the insert is guarded
+by `engagement_gate`'s own primary key (`INSERT OR IGNORE`), not a
+read-then-write, so a second device subscribing — or the same one
+resubscribing after its keys rotate — cannot reset an already-drifting
+subject back to full, and two devices racing to be the first one in cannot
+both win.
+
+The edge case worth naming: someone subscribes and then unsubscribes every
+device before ever becoming due. They keep their gate row and have no way to
+be reached. This degrades correctly rather than looping loudly — `Presence`
+(fastest half-life, highest weight) stays the dominant deficit for a subject
+who has never received a single signal, so `GetStarted` keeps firing when
+they become due, and admission fails on `NotConsented` at `info!` rather than
+falling through to `Verdict::NothingToSay`'s `warn!`.
+
+Landing this closes **P0** (`#295`'s first deployable increment): a fresh
+database, one subscription, no sessions, no signals, and the clock advanced
+is now enough to produce one notification that opens the app.
+
 ## Consent is a precondition, not a preference
 
 **The null case is silence.** There is no path through `push_repo` that creates a
@@ -288,7 +332,7 @@ All paths are under `/api/v1`.
 | Method | Path | Purpose |
 |---|---|---|
 | `GET` | `/push/vapid-key` | The `applicationServerKey` and the topics on offer |
-| `POST` | `/push/subscriptions` | The browser's `PushSubscription` **plus the topics they agreed to** |
+| `POST` | `/push/subscriptions` | The browser's `PushSubscription` **plus the topics they agreed to**, and first contact — see below |
 | `DELETE` | `/push/subscriptions` | Withdrawing consent, idempotent, body `{ endpoint }` |
 | `POST` | `/push/test` | Send now, without waiting for a day to pass |
 
@@ -298,12 +342,17 @@ All paths are under `/api/v1`.
 |---|---|---|
 | `POST` | `/signals` | A domain event: `session-started`, `session-abandoned`, `scored-below-target`, `curriculum-updated`, … |
 
-**This is where work originates.** A signal folds into the subject's charge and
-the crossing instant is re-solved on the spot; the response returns the new
-`eligible_at`, which makes the arithmetic observable without waiting for a
-notification. A cron-driven design has no endpoint like this, because nothing
-needs to tell it anything — and that convenience is exactly what costs it the
-ability to answer *why*.
+**This is where a charge is updated.** A signal folds into the subject's
+existing charge and the crossing instant is re-solved on the spot; the
+response returns the new `eligible_at`, which makes the arithmetic observable
+without waiting for a notification. A cron-driven design has no endpoint like
+this, because nothing needs to tell it anything — and that convenience is
+exactly what costs it the ability to answer *why*.
+
+It is not, since `#278`, the only place a subject *begins* to exist:
+[first contact](#first-contact-how-a-subject-enters-the-gate-at-all)
+(`POST /push/subscriptions`) writes the initial gate row, seeded full, before
+any signal has ever arrived.
 
 ### Sessions
 


### PR DESCRIPTION
## Description

`engagement_gate` rows — the waker's entire `WHERE eligible_at <= now` query surface — were created in exactly one place: `waker::observe`, called from `POST /signals`, whose only caller is the client's session-mutation layer, fired when a session is *created*. The chain was: no session ⇒ no signal ⇒ no gate row ⇒ never in `due` ⇒ never nudged. Not late — never. The client's own module said so in as many words. This is silence #1 in #257's cold-start argument.

`POST /push/subscriptions` closes it. `waker::first_contact` runs after the subscription itself is persisted: subscribing is a person explicitly saying "you may interrupt me" — the strongest statement of intent this deployment has, and it happens exactly once per device before any study behaviour exists. Alternatives considered and rejected, per the issue and recorded in `first_contact`'s doc comment:

- *Any authenticated request* — too broad; a page load is not consent.
- *A dedicated "hello" endpoint* — a new route restating what this one already implies.
- *Lazily, when the waker runs* — impossible; the waker can only see rows that already exist. This is the exact circularity the fix closes.

The row is seeded **full**, using the same `Charge::full`/`eligible_at` arithmetic `observe` already falls back to for an unseen subject — so a first-contact subject and one discovered through a stray signal land on identical footing, and `eligible_at` comes out on the order of a week later, not five minutes. Someone who installs the app at 9am must not be interrupted at 9:05.

`EngagementRepository::seed_if_absent` is new and deliberately **not** built on `save()`: `save`'s `ON CONFLICT` upserts both tables unconditionally, which is correct for folding in a new signal and wrong here — subscribing a second device, or re-subscribing the same one after key rotation, must not reset an already-drifting subject back to full. `INSERT OR IGNORE` against `engagement_gate`'s primary key is the guard, not a read-then-write, so two devices racing to be the first-ever subscription for a subject cannot both win.

The issue's named edge case — someone subscribes, then unsubscribes every device before ever becoming due — degrades correctly rather than looping loudly: `Presence` (fastest half-life, highest weight) stays the dominant deficit for a subject who has never received a single signal, so `GetStarted` (#294) keeps firing when they become due, and admission fails on `NotConsented` at `info!` rather than falling through to `Verdict::NothingToSay`'s `warn!`. Pinned by a new test in `waker.rs`.

`docs/study-nudge.md` gains a "First contact" section documenting what creates a subject, since "nothing does" was the previous answer.

Landing this closes **P0** — #295's first deployable increment — alongside #294 (P0.1, merged in #296): a fresh database, one subscription, no sessions, no signals, and the clock advanced is now enough to produce one notification that opens the app.

Fixes #278

Part of #295 (P0.2) and #257.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `cargo check --workspace` and `cargo test --workspace` against a migrated SQLite database (via `sqlx-cli`, per `docs/study-nudge.md`) — all green, no new warnings under the workspace's `-D warnings` clippy pedantic/nursery/cargo lint set.
- `cargo sqlx prepare --workspace` succeeds, validating the new `INSERT OR IGNORE` queries in `EngagementRepository::seed_if_absent` against the real schema.
- `cargo fmt --all -- --check` clean on the changed files.
- New tests, one per acceptance-criterion checkbox that is unit-testable without a live DB connection in-process:
  - `study_domain::calibration::tests::first_contact_seeds_full_so_a_brand_new_subject_is_not_instantly_eligible` — a fresh full charge is not eligible at `now`, naming `observe`'s "starts full rather than empty" constraint.
  - `study_domain::calibration::tests::first_contact_does_become_eligible_once_the_full_charge_decays_to_threshold` — the same charge does cross the threshold, with the crossing instant taken from `Charge::eligible_at` rather than a hardcoded duration.
  - `file_host::nudge::waker::tests::a_first_contact_subject_who_unsubscribed_everywhere_is_suppressed_not_stuck_with_nothing_to_say` — the zero-live-subscriptions edge case resolves to `Verdict::Suppressed(NotConsented)`, not the `warn!`-logging `NothingToSay`.
  - Idempotency (`INSERT OR IGNORE` on `engagement_gate`'s primary key) and the "row created on first subscribe" behavior are structural/SQL-level guarantees, documented in `seed_if_absent`'s doc comment; the codebase has no precedent anywhere for a runtime DB-integration test harness (no `sqlx::test`/in-memory-pool usage exists in any of the 32+ prior PRs), so this follows the same repository-layer convention as `save`, `claim`, and `release`, none of which have direct tests either.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Notes

Reference: #295 (the landing order) places this as **P0.2**, the second and last story in **P0**, the milestone's first deployable increment. #294 (P0.1, PR #296) is the other half.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MNfgPbxx8BiY6daLjn9EYA)_