### PR TITLE
P1.3 · [SLI1] The waker reads the entire session table once per due subject

### DIFF
--- a/apps/servers/file_host/src/metrics/waker.rs
+++ b/apps/servers/file_host/src/metrics/waker.rs
@@ -18,3 +18,18 @@ pub fn record_successful_pass() {
 	let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0.0, |elapsed| elapsed.as_secs_f64());
 	metrics::gauge!("nudge_waker_last_pass_timestamp_seconds").set(timestamp);
 }
+
+/// #262 (SLI1): every row `SessionRepository::list()` hands back, summed
+/// across every due subject one pass considers.
+///
+/// `list()` has no `WHERE`/`LIMIT` — see its own docstring — so this grows
+/// with `BATCH × |sessions|` on an accumulated table rather than staying flat
+/// as the fleet grows. This counter is the measurement half of that story:
+/// it makes the cost visible on a dashboard the same way the characterisation
+/// test in `nudge::waker`'s test module makes it visible in CI. Fixing the
+/// read pattern is #263 (SLI2); until then this counter is expected to climb
+/// with usage, and #263's job is to make it stop.
+pub fn record_session_rows_read(count: usize) {
+	#[allow(clippy::cast_possible_truncation)] // a session table is never near u64::MAX rows
+	metrics::counter!("nudge_waker_session_rows_read_total").increment(count as u64);
+}

--- a/apps/servers/file_host/src/nudge/waker.rs
+++ b/apps/servers/file_host/src/nudge/waker.rs
@@ -150,6 +150,10 @@ async fn consider(db: &SqlitePool, ws: &WebSocketFsm, nudge: &NudgeContext, enga
 			return Ok(false);
 		}
 	};
+	// #262 (SLI1): the measurement, not the fix. `list()` returns every row in
+	// the table regardless of which subject is asking, so this is the number
+	// this subject's consideration cost — see `metrics::waker::record_session_rows_read`.
+	crate::metrics::waker::record_session_rows_read(sessions.len());
 	let prepared_session = sessions
 		.iter()
 		.find(|session| matches!(session.status, SessionStatus::Scheduled | SessionStatus::Paused | SessionStatus::Draft))
@@ -410,6 +414,16 @@ mod tests {
 		Utc.with_ymd_and_hms(2026, 8, 5, 12, 0, 0).unwrap()
 	}
 
+	/// `format!` is on `clippy.toml`'s disallowed-macros list (eager
+	/// allocation ahead of tracing); `write!` into an owned `String` is the
+	/// same workaround #299 used for the identical lint.
+	fn numbered(prefix: &str, i: impl std::fmt::Display) -> String {
+		use std::fmt::Write as _;
+		let mut s = String::from(prefix);
+		let _ = write!(s, "{i}");
+		s
+	}
+
 	/// #278's named edge case: someone subscribes, then unsubscribes every
 	/// device before ever becoming due. `actuate` already degrades correctly
 	/// once admission fails; the risk the issue calls out is landing in
@@ -437,6 +451,144 @@ mod tests {
 		assert!(
 			matches!(verdict, Verdict::Suppressed { reason: Suppressed::NotConsented, .. }),
 			"got {verdict:?}, expected NotConsented suppression rather than NothingToSay"
+		);
+	}
+
+	/// #262 (SLI1): the measurement, not the fix (that's #263/SLI2). This is a
+	/// **characterisation test**, not an `#[ignore]`d assertion of a
+	/// not-yet-decided target bound — #262's acceptance criteria offer either,
+	/// and this is the choice, for two reasons: #263 has not picked its bound
+	/// yet, so a target number here would be invented; and a test that
+	/// actually runs in CI is a stronger regression guard between now and
+	/// #263 than one nobody runs. When #263 lands, this assertion should
+	/// invert to a small constant — not be deleted, since "the waker's read
+	/// cost stays flat as the table grows" is exactly the invariant worth
+	/// keeping under test forever after.
+	///
+	/// Seeds more due subjects than `BATCH` so the assertion exercises the
+	/// cap, not just proportionality: a fix that read once per due subject
+	/// (rather than once per subject *and* per row) would already land far
+	/// below this number, and this test would need rewriting — which is the
+	/// point of committing it now.
+	#[test]
+	fn one_pass_reads_the_whole_session_table_once_per_due_subject() {
+		use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+		use metrics_util::CompositeKey;
+		use push_kit::{ReqwestTransport, Sender, VapidIdentity};
+		use sqlx::sqlite::SqlitePoolOptions;
+
+		const DUE_SUBJECTS: i64 = 40; // > BATCH (32), so the cap itself is exercised
+		const SESSIONS: usize = 200;
+
+		// The `web-push` crate's own test vector — also what `push_kit`'s own
+		// suite signs with (`crates/push_kit/src/identity.rs`). Fixed rather
+		// than generated, so this test needs neither a random source nor a
+		// `web_push`/`base64` dev-dependency just to hand `NudgeContext` a
+		// keypair that validates against itself.
+		const VAPID_PRIVATE: &str = "IQ9Ur0ykXoHS9gzfYX0aBjy9lvdrjx_PFUXmie9YRcY";
+		const VAPID_PUBLIC: &str = "BMjQIp55pdbU8pfCBKyXcZjlmER_mXt5LqNrN1hrXbdBS5EnhIbMu3Au-RV53iIpztzNXkGI56BFB1udQ8Bq_H4";
+
+		// Embedded and run against a fresh in-memory database rather than the
+		// externally-applied `DATABASE_URL` scratch database `cargo test`
+		// already requires for `sqlx::query!` to compile: that database is
+		// one file shared by every crate's tests in one `rust_ci` run, and a
+		// row-count characterisation needs a table only this test has written
+		// to. `sqlx::migrate!` embeds the same `.up.sql`/`.down.sql` pairs at
+		// compile time, so no second migration story exists to keep in step.
+		static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("../../../migrations");
+
+		let recorder = DebuggingRecorder::new();
+		let snapshotter = recorder.snapshotter();
+
+		metrics::with_local_recorder(&recorder, || {
+			let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().expect("build a current-thread runtime");
+
+			rt.block_on(async {
+				// A single connection: SQLite's `:memory:` database is private
+				// to the connection that opened it, so a pool free to open a
+				// second one would silently hand some queries an empty,
+				// unmigrated schema. This test has no concurrency to justify
+				// more than one connection.
+				let pool = SqlitePoolOptions::new()
+					.max_connections(1)
+					.connect("sqlite::memory:")
+					.await
+					.expect("open an in-memory sqlite database");
+				MIGRATOR.run(&pool).await.expect("run the workspace migration history");
+
+				let now = Utc::now();
+				let past = (now - Duration::hours(1)).to_rfc3339();
+				let now_str = now.to_rfc3339();
+
+				for i in 0..DUE_SUBJECTS {
+					let subject_id = numbered("subject-", i);
+					EngagementRepository::new(pool.clone())
+						.seed_if_absent(&subject_id, &[], &now_str, &past)
+						.await
+						.expect("seed a due subject's gate row");
+				}
+
+				for i in 0..SESSIONS {
+					let id = numbered("session-", i);
+					let name = numbered("session ", i);
+					// Direct SQL, not `SessionRepository::upsert`: `upsert`
+					// does not write `subject_id` yet (#260/SUB2 is what
+					// threads a real subject through every query), and the
+					// column has been `NOT NULL` since #259 — a write through
+					// the repository fails on that constraint today.
+					sqlx::query!(
+						r#"
+						INSERT INTO sessions (
+							id, subject_id, name, status, layout_mode, total_duration_ms,
+							created_at, updated_at, activities, scenes, layout
+						) VALUES (?, 'subject-local', ?, 'draft', 'basic', 0, ?, ?, '[]', '[]', NULL)
+						"#,
+						id,
+						name,
+						now_str,
+						now_str,
+					)
+					.execute(&pool)
+					.await
+					.expect("seed a session row");
+				}
+
+				let ws = WebSocketFsm::new();
+				let vapid = VapidIdentity::from_config(Some(VAPID_PRIVATE), Some(VAPID_PUBLIC), "mailto:test@example.com").expect("the fixed test keypair validates");
+				let nudge = NudgeContext {
+					clock: NudgeClock::resolve(Some("UTC")).0,
+					sender: std::sync::Arc::new(Sender::new(vapid.clone(), ReqwestTransport::default())),
+					vapid,
+					enabled: true,
+					quiet_hours_start: 22,
+					quiet_hours_end: 8,
+					presence_freshness: std::time::Duration::from_secs(120),
+					base_url: "https://example.com".to_owned(),
+				};
+
+				run_once(&pool, &ws, &nudge)
+					.await
+					.expect("a pass over freshly-drafted sessions and unconsented subjects should not error");
+			});
+		});
+
+		let snapshot: Vec<(CompositeKey, Option<metrics::Unit>, Option<metrics::SharedString>, DebugValue)> = snapshotter.snapshot().into_vec();
+		let rows_read = snapshot.iter().find_map(|(key, _, _, value)| {
+			(key.key().name() == "nudge_waker_session_rows_read_total").then_some(match value {
+				DebugValue::Counter(n) => *n,
+				_ => 0,
+			})
+		});
+
+		#[allow(clippy::cast_sign_loss)] // BATCH and DUE_SUBJECTS are both small positive constants
+		let expected = BATCH.min(DUE_SUBJECTS) as u64 * SESSIONS as u64;
+		assert_eq!(
+			rows_read,
+			Some(expected),
+			"today's waker reads the whole `sessions` table once per due subject in the batch — \
+			 BATCH.min(DUE_SUBJECTS) × SESSIONS = {expected} rows. If this now fails because the \
+			 count is *lower*, #263 (SLI2) landed: rewrite this assertion to the new bound instead \
+			 of deleting the test, since a flat read cost is the invariant worth keeping."
 		);
 	}
 }

--- a/crates/db/session/src/repository.rs
+++ b/crates/db/session/src/repository.rs
@@ -121,8 +121,19 @@ impl SessionRepository {
 
 	/// Every session, newest first.
 	///
-	/// Unpaginated on purpose: the client paginates this list in memory today,
-	/// and a page parameter nobody sends is a contract nobody tests.
+	/// Unpaginated, but no longer only on the premise that justified it
+	/// originally — "the client paginates this list in memory today, and a
+	/// page parameter nobody sends is a contract nobody tests." That was true
+	/// when `GET /sessions` was the only caller. It stopped being true when
+	/// `file_host`'s engagement waker (`nudge::waker::consider`) started
+	/// calling this once per due subject to find a prepared session: the
+	/// waker has no pagination of its own to hand a page parameter to, and no
+	/// caller upstream of it either — see `docs/study-nudge.md`'s "a read
+	/// reachable from the waker declares its own bound" invariant. The
+	/// caller-paginates assumption is retracted, not just amended, since it no
+	/// longer describes every caller, only the original one. Bounding this
+	/// query is #263 (SLI2); #262 (SLI1) only characterises today's cost, in
+	/// `nudge::waker`'s test module.
 	///
 	/// # Errors
 	/// Fails on any `sqlx` error, or if a stored row does not parse.

--- a/docs/study-nudge.md
+++ b/docs/study-nudge.md
@@ -461,6 +461,26 @@ Two further brakes: an intervention **recharges** the classes it addresses, so
 the next pass finds nothing to do; and `REFRACTORY` is a hard floor whatever the
 arithmetic says.
 
+### A read reachable from the waker declares its own bound
+
+**There is no caller to paginate it.** `GET /sessions` could leave `list()`
+unpaginated because the client was the one caller, and the client already
+paginates the result in memory. `nudge::waker::consider` broke that: it calls
+`SessionRepository::list()` once per due subject to find a prepared session,
+and nothing sits above the waker to page through what comes back — the tick
+fires, the pass runs, and whatever `list()` hands back is read in full. A
+query on this path that assumes some caller will bound it is assuming a
+caller that does not exist.
+
+So the invariant is stated the other way round: **a read reachable from the
+waker declares its own bound**, in the query itself (a `LIMIT`, an indexed
+`WHERE`, or a narrower question than "everything") rather than in a caller
+that isn't there to enforce one. `list()` does not yet — `#262` (SLI1) is the
+measurement of that gap, a characterisation test in `nudge::waker`'s test
+module pinning down today's `O(BATCH × |sessions|)` cost, and `#263` (SLI2)
+is where the query itself changes. `#262` deliberately does not fix the read;
+see its own out-of-scope note.
+
 ### One policy, one language
 
 An earlier draft kept a JSON fixture so a TypeScript copy of the policy and a

--- a/scripts/check_metric_contract.py
+++ b/scripts/check_metric_contract.py
@@ -74,6 +74,7 @@ EXEMPT_EMITTED: dict[str, str] = {
 	"operation_errors_total": "file_host per-operation error counter; no dedicated panel yet, tracked for a future operational-detail row rather than this uptime/SLA dashboard",
 	"file_downloads_total": "file_host per-download counter; no dedicated panel yet, same as operation_errors_total",
 	"file_size_bytes": "file_host download-size histogram; no dedicated panel yet, same as operation_errors_total",
+	"nudge_waker_session_rows_read_total": "#262 (SLI1): the measurement for the waker's per-subject session read cost, landed deliberately ahead of a dashboard reader — the story is the counter and a characterisation test (nudge::waker's test module), not a panel. A panel is reasonable once #263 (SLI2) gives this series a shape worth graphing (today it just climbs with usage); tracked the same way as the other three entries above.",
 }
 
 METRICS_FACADE_CALL = re.compile(r'\b(?:counter|histogram|gauge)!\s*\(\s*(?:"([^"]+)"|([A-Z_][A-Z0-9_]*))')


### PR DESCRIPTION
## Description

`nudge::waker::consider` calls `SessionRepository::list()` once per due subject to find a prepared session. `list()` is `SELECT … FROM sessions ORDER BY created_at DESC` with no `WHERE`/`LIMIT` — its docstring justified that as "the client paginates this list in memory today, and a page parameter nobody sends is a contract nobody tests," which was true when `GET /sessions` was the only caller. The waker made it false without amending it: one pass is `O(BATCH × |sessions|)` full-row JSON deserialisations to answer "is there one prepared session?" — an answer that is at most one row.

Per #262's own framing, **the fix is a separate story (#263/SLI2)**. This PR is the measurement and the guard that fix will need to be verifiable against:

- A `nudge_waker_session_rows_read_total` metrics counter (`file_host::metrics::waker::record_session_rows_read`), incremented in `consider` right after `SessionRepository::list()` returns, with every row it handed back.
- A **characterisation test** (`nudge::waker::tests::one_pass_reads_the_whole_session_table_once_per_due_subject`) — chosen over an `#[ignore]`d test asserting a not-yet-decided target bound, because #263 hasn't picked its bound yet (a target number here would be invented) and a test that actually runs in CI is a stronger regression guard between now and then than one nobody runs. It seeds 40 due subjects (> `BATCH` = 32, so the cap itself is exercised) and 200 sessions into a freshly migrated in-memory SQLite database (embedded via `sqlx::migrate!`, isolated from the shared `DATABASE_URL` scratch database `rust_ci` uses for compile-time query verification), runs `run_once`, and asserts the counter reads exactly `BATCH.min(DUE_SUBJECTS) × SESSIONS` rows. When #263 lands, this assertion should invert to a small constant rather than be deleted — "the waker's read cost stays flat as the table grows" is the invariant worth keeping under test permanently.
- `SessionRepository::list()`'s docstring (`crates/db/session/src/repository.rs`) is amended to name the waker as a caller and retract the "caller paginates" assumption — it's no longer true for every caller, only the original one.
- `docs/study-nudge.md` gains a new invariant, "a read reachable from the waker declares its own bound," explaining why: nothing sits above the waker to page through what `list()` hands back.

Out of scope, per #262: actually bounding the read (#263), retention on other tables (#265/SLI4), changing `BATCH`.

Fixes #262
Part of #295 (P1.3) — the last unlanded row in P1; P1 closes once this merges.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) — no behavior change; adds measurement/observability and a characterisation test only.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- `cargo test -p file_host nudge::waker::tests` — both the new characterisation test and the existing `#278` unit test pass.
- Sanity-checked the new test actually gates on the real count: temporarily hardcoded a wrong `expected` value and confirmed the assertion fails; reverted before committing.
- `cargo check --workspace` and `cargo test --workspace --verbose` — full workspace green, no failures.
- `cargo clippy -p file_host --no-deps --all-targets`, filtered to the two touched files: no `disallowed_macros` or other new violations. The only findings left are `clippy::expect_used` on the new test's `.expect(...)` setup calls, which is the identical pattern already present (and unaddressed) in the existing `websocket.rs` test this test's structure is modeled on — not a regression, and `lint.yml` doesn't gate PRs today regardless.
- `cargo fmt --all -- --check` filtered to touched files: the one hit is a pre-existing, untouched `assert!` block shifted by my earlier insertions (confirmed via `git diff` it isn't part of this change) — the known nightly-vs-stable `rustfmt.toml` false positive.
- `cargo sqlx prepare --workspace` succeeds against the touched query.

**Test Configuration**:
* Toolchain: stable, `sqlx-cli` 0.7.4 (matches `test.yml`'s pin)
* SDK: workspace `migrations/` staged and applied to a scratch `DATABASE_URL` for compile-time `sqlx::query!` verification; the new test itself embeds its own migrator against an isolated in-memory database.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (see clippy note above)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules — n/a

## Additional Notes

Continues the landing order in #295: follows #294 (P0.1/#296), #278 (P0.2/#297), #259 (P1.1/#298), #266 (P1.2/#299). This is the last row of P1 — once merged, P2 (starting with #260) is next per #295, gated on a fresh re-read of that issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_016HiRNVqwWXQkK9vgV9cM3e)_