### PR TITLE
P2.1 · [SUB2] SessionRepository takes a subject on every method that is not an admin read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5082,6 +5082,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tokio",
 ]
 
 [[package]]

--- a/apps/servers/file_host/src/handlers/db/session.rs
+++ b/apps/servers/file_host/src/handlers/db/session.rs
@@ -24,6 +24,7 @@
 //! Every mutating call returns the full record, because the client's
 //! repositories already do and its react-query cache depends on it.
 
+use crate::subject::SINGLETON_SUBJECT;
 use crate::{AppState, FileHostError};
 use axum::{
 	extract::{Path, State},
@@ -62,7 +63,12 @@ fn to_http(err: &session_repo::repository::SessionRepoError) -> FileHostError {
 #[axum::debug_handler]
 #[instrument(name = "list_sessions", skip_all, fields(otel.kind = "server"))]
 pub async fn list_sessions(State(state): State<AppState>) -> Result<Json<Vec<SessionRecord>>, FileHostError> {
-	repo(&state).list().await.map(Json).map_err(|err| to_http(&err))
+	// `SINGLETON_SUBJECT` rather than an extracted `SubjectId`: threading a
+	// real subject through the route layer is #261 (SUB3). This story only
+	// guarantees the repository *can* be scoped; #261's own acceptance
+	// criterion (`grep -rn "SINGLETON_SUBJECT"` outside `subject.rs` finds
+	// nothing) is what retires every reference like this one.
+	repo(&state).list(SINGLETON_SUBJECT).await.map(Json).map_err(|err| to_http(&err))
 }
 
 /// `GET /sessions/:id`
@@ -72,7 +78,12 @@ pub async fn list_sessions(State(state): State<AppState>) -> Result<Json<Vec<Ses
 #[axum::debug_handler]
 #[instrument(name = "get_session", skip_all, fields(otel.kind = "server"))]
 pub async fn get_session(State(state): State<AppState>, Path(id): Path<String>) -> Result<Json<SessionRecord>, FileHostError> {
-	repo(&state).get(&id).await.map_err(|err| to_http(&err))?.map(Json).ok_or(FileHostError::NotFound)
+	repo(&state)
+		.get(SINGLETON_SUBJECT, &id)
+		.await
+		.map_err(|err| to_http(&err))?
+		.map(Json)
+		.ok_or(FileHostError::NotFound)
 }
 
 /// `POST /sessions`
@@ -102,7 +113,7 @@ pub async fn create_session(State(state): State<AppState>, Json(input): Json<Cre
 		final_elapsed_ms: None,
 	};
 
-	repo(&state).upsert(&record).await.map_err(|err| to_http(&err))?;
+	repo(&state).upsert(SINGLETON_SUBJECT, &record).await.map_err(|err| to_http(&err))?;
 	Ok(Json(record))
 }
 
@@ -111,7 +122,7 @@ pub async fn create_session(State(state): State<AppState>, Json(input): Json<Cre
 #[instrument(name = "update_session", skip_all, fields(otel.kind = "server"))]
 pub async fn update_session(State(state): State<AppState>, Path(id): Path<String>, Json(patch): Json<UpdateSession>) -> Result<Json<SessionRecord>, FileHostError> {
 	let sessions = repo(&state);
-	let mut record = sessions.get(&id).await.map_err(|err| to_http(&err))?.ok_or(FileHostError::NotFound)?;
+	let mut record = sessions.get(SINGLETON_SUBJECT, &id).await.map_err(|err| to_http(&err))?.ok_or(FileHostError::NotFound)?;
 
 	// A patch is `Partial<...>`: absent means "leave it". The one exception is
 	// `layout`, where absent and explicit-null differ — see `deserialize_explicit_null`.
@@ -151,7 +162,7 @@ pub async fn update_session(State(state): State<AppState>, Path(id): Path<String
 	}
 
 	record.updated_at = Utc::now().to_rfc3339();
-	sessions.upsert(&record).await.map_err(|err| to_http(&err))?;
+	sessions.upsert(SINGLETON_SUBJECT, &record).await.map_err(|err| to_http(&err))?;
 	Ok(Json(record))
 }
 
@@ -159,7 +170,7 @@ pub async fn update_session(State(state): State<AppState>, Path(id): Path<String
 #[axum::debug_handler]
 #[instrument(name = "delete_session", skip_all, fields(otel.kind = "server"))]
 pub async fn delete_session(State(state): State<AppState>, Path(id): Path<String>) -> Result<Json<serde_json::Value>, FileHostError> {
-	let removed = repo(&state).delete(&id).await.map_err(|err| to_http(&err))?;
+	let removed = repo(&state).delete(SINGLETON_SUBJECT, &id).await.map_err(|err| to_http(&err))?;
 	Ok(Json(serde_json::json!({ "removed": removed })))
 }
 
@@ -167,7 +178,7 @@ pub async fn delete_session(State(state): State<AppState>, Path(id): Path<String
 #[axum::debug_handler]
 #[instrument(name = "delete_sessions", skip_all, fields(otel.kind = "server"))]
 pub async fn delete_sessions(State(state): State<AppState>, Json(request): Json<RemoveManyRequest>) -> Result<Json<serde_json::Value>, FileHostError> {
-	let deleted = repo(&state).delete_many(&request.ids).await.map_err(|err| to_http(&err))?;
+	let deleted = repo(&state).delete_many(SINGLETON_SUBJECT, &request.ids).await.map_err(|err| to_http(&err))?;
 	Ok(Json(serde_json::json!({ "deletedCount": deleted })))
 }
 
@@ -176,7 +187,7 @@ pub async fn delete_sessions(State(state): State<AppState>, Json(request): Json<
 #[instrument(name = "set_session_status", skip_all, fields(otel.kind = "server"))]
 pub async fn set_status(State(state): State<AppState>, Json(request): Json<StatusManyRequest>) -> Result<Json<Vec<SessionRecord>>, FileHostError> {
 	repo(&state)
-		.set_status_many(&request.ids, request.status, &Utc::now().to_rfc3339())
+		.set_status_many(SINGLETON_SUBJECT, &request.ids, request.status, &Utc::now().to_rfc3339())
 		.await
 		.map(Json)
 		.map_err(|err| to_http(&err))
@@ -192,7 +203,7 @@ pub async fn set_status(State(state): State<AppState>, Json(request): Json<Statu
 #[instrument(name = "duplicate_session", skip_all, fields(otel.kind = "server"))]
 pub async fn duplicate_session(State(state): State<AppState>, Path(id): Path<String>) -> Result<Json<SessionRecord>, FileHostError> {
 	let sessions = repo(&state);
-	let source = sessions.get(&id).await.map_err(|err| to_http(&err))?.ok_or(FileHostError::NotFound)?;
+	let source = sessions.get(SINGLETON_SUBJECT, &id).await.map_err(|err| to_http(&err))?.ok_or(FileHostError::NotFound)?;
 	let now = Utc::now().to_rfc3339();
 
 	let copy = SessionRecord {
@@ -206,7 +217,7 @@ pub async fn duplicate_session(State(state): State<AppState>, Path(id): Path<Str
 		..source
 	};
 
-	sessions.upsert(&copy).await.map_err(|err| to_http(&err))?;
+	sessions.upsert(SINGLETON_SUBJECT, &copy).await.map_err(|err| to_http(&err))?;
 	Ok(Json(copy))
 }
 

--- a/apps/servers/file_host/src/nudge/waker.rs
+++ b/apps/servers/file_host/src/nudge/waker.rs
@@ -143,16 +143,19 @@ async fn consider(db: &SqlitePool, ws: &WebSocketFsm, nudge: &NudgeContext, enga
 	// `SessionRepoError` doesn't convert to this function's `sqlx::Error`, and
 	// widening the signature is a bigger change than a rare read failure
 	// warrants.
-	let sessions = match SessionRepository::new(db.clone()).list().await {
+	let sessions = match SessionRepository::new(db.clone()).list(subject_id).await {
 		Ok(sessions) => sessions,
 		Err(err) => {
 			error!(subject = %subject_id, error = %err, "could not read sessions; skipping this subject rather than guessing whether one is prepared");
 			return Ok(false);
 		}
 	};
-	// #262 (SLI1): the measurement, not the fix. `list()` returns every row in
-	// the table regardless of which subject is asking, so this is the number
-	// this subject's consideration cost — see `metrics::waker::record_session_rows_read`.
+	// #262 (SLI1): the measurement, not the fix. `list()` is scoped to this
+	// subject as of #260 (SUB2) — it can no longer return another subject's
+	// rows — but it is still unbounded *within* that scope, so this is still
+	// this subject's full session count, not the one row `consider` actually
+	// needs. See `metrics::waker::record_session_rows_read`. #263 (SLI2)
+	// replaces this call with a purpose-built `first_prepared` lookup.
 	crate::metrics::waker::record_session_rows_read(sessions.len());
 	let prepared_session = sessions
 		.iter()
@@ -467,18 +470,30 @@ mod tests {
 	///
 	/// Seeds more due subjects than `BATCH` so the assertion exercises the
 	/// cap, not just proportionality: a fix that read once per due subject
-	/// (rather than once per subject *and* per row) would already land far
-	/// below this number, and this test would need rewriting — which is the
-	/// point of committing it now.
+	/// (rather than once per subject *and* per row it owns) would already
+	/// land far below this number, and this test would need rewriting —
+	/// which is the point of committing it now.
+	///
+	/// Each due subject owns its own `SESSIONS_PER_SUBJECT` sessions, seeded
+	/// through `SessionRepository::upsert` rather than a shared pool of rows
+	/// under one id. Before #260 (SUB2), `list()` had no `WHERE subject_id`
+	/// clause at all, so every subject's pass genuinely re-read the same
+	/// whole table; #260 scoped that query, so a table shared across subjects
+	/// would no longer demonstrate the defect this test exists to catch — a
+	/// query that provably cannot see another subject's rows is not
+	/// "unbounded" in the sense SLI1 means. What's still true, and still
+	/// worth a test until #263, is that each subject's *own* read stays
+	/// unbounded within that scope.
 	#[test]
-	fn one_pass_reads_the_whole_session_table_once_per_due_subject() {
+	fn one_pass_reads_each_due_subjects_entire_session_set_once() {
 		use metrics_util::debugging::{DebugValue, DebuggingRecorder};
 		use metrics_util::CompositeKey;
 		use push_kit::{ReqwestTransport, Sender, VapidIdentity};
+		use session_repo::{LayoutMode, SessionRecord};
 		use sqlx::sqlite::SqlitePoolOptions;
 
 		const DUE_SUBJECTS: i64 = 40; // > BATCH (32), so the cap itself is exercised
-		const SESSIONS: usize = 200;
+		const SESSIONS_PER_SUBJECT: usize = 5;
 
 		// The `web-push` crate's own test vector — also what `push_kit`'s own
 		// suite signs with (`crates/push_kit/src/identity.rs`). Fixed rather
@@ -520,37 +535,35 @@ mod tests {
 				let past = (now - Duration::hours(1)).to_rfc3339();
 				let now_str = now.to_rfc3339();
 
+				let sessions_repo = SessionRepository::new(pool.clone());
 				for i in 0..DUE_SUBJECTS {
 					let subject_id = numbered("subject-", i);
 					EngagementRepository::new(pool.clone())
 						.seed_if_absent(&subject_id, &[], &now_str, &past)
 						.await
 						.expect("seed a due subject's gate row");
-				}
 
-				for i in 0..SESSIONS {
-					let id = numbered("session-", i);
-					let name = numbered("session ", i);
-					// Direct SQL, not `SessionRepository::upsert`: `upsert`
-					// does not write `subject_id` yet (#260/SUB2 is what
-					// threads a real subject through every query), and the
-					// column has been `NOT NULL` since #259 — a write through
-					// the repository fails on that constraint today.
-					sqlx::query!(
-						r#"
-						INSERT INTO sessions (
-							id, subject_id, name, status, layout_mode, total_duration_ms,
-							created_at, updated_at, activities, scenes, layout
-						) VALUES (?, 'subject-local', ?, 'draft', 'basic', 0, ?, ?, '[]', '[]', NULL)
-						"#,
-						id,
-						name,
-						now_str,
-						now_str,
-					)
-					.execute(&pool)
-					.await
-					.expect("seed a session row");
+					for j in 0..SESSIONS_PER_SUBJECT {
+						use std::fmt::Write as _;
+						let mut id = String::from("session-");
+						let _ = write!(id, "{i}-{j}");
+						let record = SessionRecord {
+							name: id.clone(),
+							id,
+							status: SessionStatus::Draft,
+							activities: Vec::new(),
+							scenes: Vec::new(),
+							layout_mode: LayoutMode::Basic,
+							layout: None,
+							total_duration_ms: 0,
+							created_at: now_str.clone(),
+							updated_at: now_str.clone(),
+							started_at: None,
+							completed_at: None,
+							final_elapsed_ms: None,
+						};
+						sessions_repo.upsert(&subject_id, &record).await.expect("seed a session row owned by this due subject");
+					}
 				}
 
 				let ws = WebSocketFsm::new();
@@ -581,14 +594,15 @@ mod tests {
 		});
 
 		#[allow(clippy::cast_sign_loss)] // BATCH and DUE_SUBJECTS are both small positive constants
-		let expected = BATCH.min(DUE_SUBJECTS) as u64 * SESSIONS as u64;
+		let expected = BATCH.min(DUE_SUBJECTS) as u64 * SESSIONS_PER_SUBJECT as u64;
 		assert_eq!(
 			rows_read,
 			Some(expected),
-			"today's waker reads the whole `sessions` table once per due subject in the batch — \
-			 BATCH.min(DUE_SUBJECTS) × SESSIONS = {expected} rows. If this now fails because the \
-			 count is *lower*, #263 (SLI2) landed: rewrite this assertion to the new bound instead \
-			 of deleting the test, since a flat read cost is the invariant worth keeping."
+			"today's waker reads a due subject's entire owned session set once per pass — \
+			 BATCH.min(DUE_SUBJECTS) × SESSIONS_PER_SUBJECT = {expected} rows. If this now fails \
+			 because the count is *lower*, #263 (SLI2) landed: rewrite this assertion to the new \
+			 bound instead of deleting the test, since a flat read cost is the invariant worth \
+			 keeping."
 		);
 	}
 }

--- a/crates/db/session/Cargo.toml
+++ b/crates/db/session/Cargo.toml
@@ -16,5 +16,8 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio-native-tls", "sqlite", "uuid", "time"] }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
 [lints]
 workspace = true

--- a/crates/db/session/src/repository.rs
+++ b/crates/db/session/src/repository.rs
@@ -77,6 +77,16 @@ pub enum SessionRepoError {
 	Row(RowError),
 	/// Serializing one of the JSON columns on the way in.
 	Serialize(serde_json::Error),
+	/// `upsert` targeted an id that already exists under a different subject.
+	///
+	/// Not folded into `Sqlx`: nothing failed at the database layer — the
+	/// `ON CONFLICT ... WHERE` guard did exactly what it was asked and left
+	/// the row untouched. Surfacing that as a distinct, named outcome is what
+	/// makes "silently no-op" impossible for a caller to mistake for success;
+	/// see `upsert`'s own doc comment for the mechanism.
+	SubjectMismatch {
+		id: String,
+	},
 }
 
 impl std::fmt::Display for SessionRepoError {
@@ -85,6 +95,7 @@ impl std::fmt::Display for SessionRepoError {
 			Self::Sqlx(err) => write!(f, "{err}"),
 			Self::Row(err) => write!(f, "{err}"),
 			Self::Serialize(err) => write!(f, "could not serialize session JSON: {err}"),
+			Self::SubjectMismatch { id } => write!(f, "session `{id}` exists under a different subject; refusing to move it"),
 		}
 	}
 }
@@ -119,7 +130,7 @@ impl SessionRepository {
 		Self { pool }
 	}
 
-	/// Every session, newest first.
+	/// Every session belonging to one subject, newest first.
 	///
 	/// Unpaginated, but no longer only on the premise that justified it
 	/// originally — "the client paginates this list in memory today, and a
@@ -131,13 +142,18 @@ impl SessionRepository {
 	/// caller upstream of it either — see `docs/study-nudge.md`'s "a read
 	/// reachable from the waker declares its own bound" invariant. The
 	/// caller-paginates assumption is retracted, not just amended, since it no
-	/// longer describes every caller, only the original one. Bounding this
-	/// query is #263 (SLI2); #262 (SLI1) only characterises today's cost, in
-	/// `nudge::waker`'s test module.
+	/// longer describes every caller, only the original one.
+	///
+	/// `subject_id` (#260/SUB2) narrows the scan to one person's rows but does
+	/// not bound its size — a subject with thousands of sessions still reads
+	/// all of them. That bound is #263 (SLI2), which replaces the waker's
+	/// caller with a purpose-built `first_prepared` query instead of tightening
+	/// this one; #262 (SLI1) characterises today's cost, in `nudge::waker`'s
+	/// test module.
 	///
 	/// # Errors
 	/// Fails on any `sqlx` error, or if a stored row does not parse.
-	pub async fn list(&self) -> Result<Vec<SessionRecord>, SessionRepoError> {
+	pub async fn list(&self, subject_id: &str) -> Result<Vec<SessionRecord>, SessionRepoError> {
 		let rows = sqlx::query_as!(
 			SessionRow,
 			r#"
@@ -146,8 +162,10 @@ impl SessionRepository {
 			    created_at, updated_at, started_at, completed_at, final_elapsed_ms,
 			    activities, scenes, layout
 			FROM sessions
+			WHERE subject_id = ?
 			ORDER BY created_at DESC
-			"#
+			"#,
+			subject_id
 		)
 		.fetch_all(&self.pool)
 		.await?;
@@ -155,11 +173,18 @@ impl SessionRepository {
 		rows.into_iter().map(|row| SessionRecord::try_from(row).map_err(Into::into)).collect()
 	}
 
-	/// One session, or `None` if there is no such id.
+	/// One session, or `None` if there is no such id **owned by this subject**.
+	///
+	/// An id belonging to another subject returns `None`, the same as an id
+	/// that does not exist at all — deliberately indistinguishable from the
+	/// caller's side. An id is not a capability: if a foreign id returned a
+	/// distinguishable "exists, but not yours" outcome, that difference would
+	/// itself leak whether the id is in use, which is exactly the kind of
+	/// answer this method should not be able to give.
 	///
 	/// # Errors
 	/// Fails on any `sqlx` error, or if the stored row does not parse.
-	pub async fn get(&self, id: &str) -> Result<Option<SessionRecord>, SessionRepoError> {
+	pub async fn get(&self, subject_id: &str, id: &str) -> Result<Option<SessionRecord>, SessionRepoError> {
 		let row = sqlx::query_as!(
 			SessionRow,
 			r#"
@@ -168,9 +193,10 @@ impl SessionRepository {
 			    created_at, updated_at, started_at, completed_at, final_elapsed_ms,
 			    activities, scenes, layout
 			FROM sessions
-			WHERE id = ?
+			WHERE id = ? AND subject_id = ?
 			"#,
-			id
+			id,
+			subject_id
 		)
 		.fetch_optional(&self.pool)
 		.await?;
@@ -183,9 +209,28 @@ impl SessionRepository {
 	/// carrying a browser's existing `createdAt` across, and this layer should
 	/// not overwrite any of those with `now`.
 	///
+	/// `subject_id` is not a `SessionRecord` field: the record type mirrors
+	/// the client's wire shape field-for-field (see this crate's docs), and
+	/// ownership is a server-only concept the client never sends. It is
+	/// written on `INSERT` and, deliberately, **never on the `UPDATE` half**
+	/// of the upsert — `subject_id` does not appear in the `SET` list, so an
+	/// edit of an owned row cannot change who owns it even if the caller
+	/// passed a different one by mistake.
+	///
+	/// A conflict on an id owned by a *different* subject is refused outright
+	/// rather than silently skipped: the `ON CONFLICT ... WHERE` guard makes
+	/// the `DO UPDATE` a no-op in that case, which `SQLite` reports as zero rows
+	/// affected. Zero is otherwise unreachable here — a fresh id always
+	/// inserts one row, and a conflict on an id this subject owns always
+	/// updates one — so it uniquely identifies the mismatch, and this method
+	/// turns it into [`SessionRepoError::SubjectMismatch`] instead of letting
+	/// a caller read "zero rows changed" as "nothing to do."
+	///
 	/// # Errors
-	/// Fails on any `sqlx` error, or if the record's JSON does not serialize.
-	pub async fn upsert(&self, record: &SessionRecord) -> Result<(), SessionRepoError> {
+	/// Fails on any `sqlx` error, if the record's JSON does not serialize, or
+	/// with [`SessionRepoError::SubjectMismatch`] if `id` already belongs to
+	/// another subject.
+	pub async fn upsert(&self, subject_id: &str, record: &SessionRecord) -> Result<(), SessionRepoError> {
 		let status = record.status.as_str();
 		let layout_mode = record.layout_mode.as_str();
 		// `serde_json::to_string` is on clippy.toml's disallowed list to keep
@@ -199,14 +244,14 @@ impl SessionRepository {
 			record.layout.as_ref().map(serde_json::to_string).transpose()?,
 		);
 
-		sqlx::query!(
+		let result = sqlx::query!(
 			r#"
 			INSERT INTO sessions (
-			    id, name, status, layout_mode, total_duration_ms,
+			    id, subject_id, name, status, layout_mode, total_duration_ms,
 			    created_at, updated_at, started_at, completed_at, final_elapsed_ms,
 			    activities, scenes, layout
 			)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(id) DO UPDATE SET
 			    name              = excluded.name,
 			    status            = excluded.status,
@@ -219,8 +264,10 @@ impl SessionRepository {
 			    activities        = excluded.activities,
 			    scenes            = excluded.scenes,
 			    layout            = excluded.layout
+			WHERE sessions.subject_id = excluded.subject_id
 			"#,
 			record.id,
+			subject_id,
 			record.name,
 			status,
 			layout_mode,
@@ -237,59 +284,90 @@ impl SessionRepository {
 		.execute(&self.pool)
 		.await?;
 
+		if result.rows_affected() == 0 {
+			return Err(SessionRepoError::SubjectMismatch { id: record.id.clone() });
+		}
+
 		Ok(())
 	}
 
-	/// Remove one session. Returns whether a row was actually removed, so a
-	/// caller that cares about 404 can tell.
+	/// Remove one session **owned by this subject**. Returns whether a row was
+	/// actually removed, so a caller that cares about 404 can tell.
+	///
+	/// A foreign id is a no-op, not a deletion — the `WHERE` clause simply
+	/// matches nothing, and the caller sees `Ok(false)`, the same outcome as
+	/// an id that never existed.
 	///
 	/// # Errors
 	/// Propagates any `sqlx` failure from the underlying statement.
-	pub async fn delete(&self, id: &str) -> Result<bool, SessionRepoError> {
-		let result = sqlx::query!("DELETE FROM sessions WHERE id = ?", id).execute(&self.pool).await?;
+	pub async fn delete(&self, subject_id: &str, id: &str) -> Result<bool, SessionRepoError> {
+		let result = sqlx::query!("DELETE FROM sessions WHERE id = ? AND subject_id = ?", id, subject_id)
+			.execute(&self.pool)
+			.await?;
 		Ok(result.rows_affected() > 0)
 	}
 
-	/// Remove several, in one transaction so a partial delete cannot survive a
-	/// failure halfway through.
+	/// Remove several **owned by this subject**, in one transaction so a
+	/// partial delete cannot survive a failure halfway through.
+	///
+	/// A foreign id among `ids` is skipped, not deleted, and does not count
+	/// toward the returned total — the same scoping as [`Self::delete`],
+	/// applied per row.
 	///
 	/// # Errors
 	/// Propagates any `sqlx` failure from the underlying statements.
-	pub async fn delete_many(&self, ids: &[String]) -> Result<u64, SessionRepoError> {
+	pub async fn delete_many(&self, subject_id: &str, ids: &[String]) -> Result<u64, SessionRepoError> {
 		let mut tx = self.pool.begin().await?;
 		let mut deleted = 0_u64;
 
 		for id in ids {
-			deleted += sqlx::query!("DELETE FROM sessions WHERE id = ?", id).execute(&mut *tx).await?.rows_affected();
+			deleted += sqlx::query!("DELETE FROM sessions WHERE id = ? AND subject_id = ?", id, subject_id)
+				.execute(&mut *tx)
+				.await?
+				.rows_affected();
 		}
 
 		tx.commit().await?;
 		Ok(deleted)
 	}
 
-	/// Set one status across a group, and return the affected records.
+	/// Set one status across a group **owned by this subject**, and return the
+	/// affected records.
 	///
 	/// Status is the only field it is coherent to set identically across an
 	/// arbitrary group — the client's `updateStatusMany` makes the same
 	/// argument, and this is its server half.
 	///
+	/// A foreign id among `ids` is left untouched by the `UPDATE` and then
+	/// excluded by [`Self::get`]'s own subject scoping, so it is silently
+	/// absent from the returned `Vec` rather than reported as an error —
+	/// consistent with `ids` already being allowed to name ids that do not
+	/// exist at all. The length of the returned `Vec` is how many of `ids`
+	/// were actually owned and updated.
+	///
 	/// # Errors
 	/// Fails on any `sqlx` error, or if a stored row does not parse.
-	pub async fn set_status_many(&self, ids: &[String], status: SessionStatus, now: &str) -> Result<Vec<SessionRecord>, SessionRepoError> {
+	pub async fn set_status_many(&self, subject_id: &str, ids: &[String], status: SessionStatus, now: &str) -> Result<Vec<SessionRecord>, SessionRepoError> {
 		let status_text = status.as_str();
 		let mut tx = self.pool.begin().await?;
 
 		for id in ids {
-			sqlx::query!("UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?", status_text, now, id)
-				.execute(&mut *tx)
-				.await?;
+			sqlx::query!(
+				"UPDATE sessions SET status = ?, updated_at = ? WHERE id = ? AND subject_id = ?",
+				status_text,
+				now,
+				id,
+				subject_id
+			)
+			.execute(&mut *tx)
+			.await?;
 		}
 
 		tx.commit().await?;
 
 		let mut updated = Vec::with_capacity(ids.len());
 		for id in ids {
-			if let Some(record) = self.get(id).await? {
+			if let Some(record) = self.get(subject_id, id).await? {
 				updated.push(record);
 			}
 		}
@@ -297,18 +375,21 @@ impl SessionRepository {
 		Ok(updated)
 	}
 
-	/// Sessions whose `started_at` or `completed_at` falls on a given local
-	/// day, expressed as the half-open UTC instant range `[from, to)` the
-	/// caller's timezone maps that day to.
+	/// Sessions **owned by this subject** whose `started_at` or `completed_at`
+	/// falls on a given local day, expressed as the half-open UTC instant
+	/// range `[from, to)` the caller's timezone maps that day to.
 	///
 	/// The range is computed by the caller rather than here because "which day
 	/// is it" is a single decision that belongs in one place —
 	/// `file_host::nudge::clock` — and a second implementation in SQL is a
-	/// second place to be wrong. Both indexed columns are covered.
+	/// second place to be wrong. `idx_sessions_started_at`/`_completed_at`
+	/// cover the time predicate; neither leads with `subject_id`, so this scan
+	/// costs an extra filter pass rather than an extra index seek until this
+	/// method gains a caller that makes tuning it worthwhile.
 	///
 	/// # Errors
 	/// Fails on any `sqlx` error, or if a stored row does not parse.
-	pub async fn touched_between(&self, from: &str, to: &str) -> Result<Vec<SessionRecord>, SessionRepoError> {
+	pub async fn touched_between(&self, subject_id: &str, from: &str, to: &str) -> Result<Vec<SessionRecord>, SessionRepoError> {
 		let rows = sqlx::query_as!(
 			SessionRow,
 			r#"
@@ -317,15 +398,189 @@ impl SessionRepository {
 			    created_at, updated_at, started_at, completed_at, final_elapsed_ms,
 			    activities, scenes, layout
 			FROM sessions
-			WHERE (started_at   >= ?1 AND started_at   < ?2)
-			   OR (completed_at >= ?1 AND completed_at < ?2)
+			WHERE subject_id = ?3
+			  AND ((started_at   >= ?1 AND started_at   < ?2)
+			   OR  (completed_at >= ?1 AND completed_at < ?2))
 			"#,
 			from,
-			to
+			to,
+			subject_id
 		)
 		.fetch_all(&self.pool)
 		.await?;
 
 		rows.into_iter().map(|row| SessionRecord::try_from(row).map_err(Into::into)).collect()
+	}
+}
+
+/// #260 (SUB2): every method above is scoped to a subject; these tests are
+/// what "scoped" means made concrete — a foreign subject's calls must not be
+/// able to read, mutate, or move a row they do not own.
+///
+/// Run against a fresh in-memory database per test rather than the
+/// externally-applied `DATABASE_URL` scratch database `cargo test` already
+/// needs for `sqlx::query!` to compile: that database is one file shared by
+/// every crate's tests in one `rust_ci` run, and cross-subject isolation is
+/// exactly the kind of property a shared, accumulating table would make
+/// unreliable to assert. `sqlx::migrate!` embeds the same `.up.sql`/`.down.sql`
+/// pairs this workspace already has at compile time — the same choice #262
+/// made in `nudge::waker`'s test module (`apps/servers/file_host`), reused
+/// here rather than reinvented. This crate has no `AppState`/waker machinery
+/// to stand up, so unlike that test, a plain `#[tokio::test]` is enough: there
+/// is no synchronous metrics-recorder API here to wrap the runtime around.
+#[cfg(test)]
+mod tests {
+	use super::{SessionRepoError, SessionRepository};
+	use crate::model::{LayoutMode, SessionRecord, SessionStatus};
+	use sqlx::sqlite::SqlitePoolOptions;
+	use sqlx::SqlitePool;
+
+	static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("../../../migrations");
+
+	async fn pool() -> SqlitePool {
+		// One connection: SQLite's `:memory:` database is private to the
+		// connection that opened it, so a pool free to open a second one
+		// could silently hand a query an empty, unmigrated schema.
+		let pool = SqlitePoolOptions::new()
+			.max_connections(1)
+			.connect("sqlite::memory:")
+			.await
+			.expect("open an in-memory sqlite database");
+		MIGRATOR.run(&pool).await.expect("run the workspace migration history");
+		pool
+	}
+
+	fn fixture(id: &str) -> SessionRecord {
+		let mut name = id.to_owned();
+		name.push_str(" name");
+		SessionRecord {
+			id: id.to_owned(),
+			name,
+			status: SessionStatus::Draft,
+			activities: Vec::new(),
+			scenes: Vec::new(),
+			layout_mode: LayoutMode::Basic,
+			layout: None,
+			total_duration_ms: 0,
+			created_at: "2026-01-01T00:00:00Z".to_owned(),
+			updated_at: "2026-01-01T00:00:00Z".to_owned(),
+			started_at: None,
+			completed_at: None,
+			final_elapsed_ms: None,
+		}
+	}
+
+	#[tokio::test]
+	async fn list_returns_only_this_subjects_sessions() {
+		let pool = pool().await;
+		let repo = SessionRepository::new(pool);
+
+		repo.upsert("subject-a", &fixture("session-a")).await.expect("seed subject-a's session");
+		repo.upsert("subject-b", &fixture("session-b")).await.expect("seed subject-b's session");
+
+		let a_sessions = repo.list("subject-a").await.expect("list subject-a's sessions");
+		assert_eq!(a_sessions.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(), vec!["session-a"]);
+	}
+
+	#[tokio::test]
+	async fn get_returns_none_for_a_well_formed_id_owned_by_a_different_subject() {
+		let pool = pool().await;
+		let repo = SessionRepository::new(pool);
+		repo.upsert("subject-a", &fixture("session-1")).await.expect("seed subject-a's session");
+
+		assert!(
+			repo.get("subject-b", "session-1").await.expect("query should not fail").is_none(),
+			"a foreign subject must not be able to read the row"
+		);
+		assert!(
+			repo.get("subject-a", "session-1").await.expect("query should not fail").is_some(),
+			"the owning subject must still be able to read it"
+		);
+	}
+
+	#[tokio::test]
+	async fn delete_cannot_remove_a_row_owned_by_another_subject() {
+		let pool = pool().await;
+		let repo = SessionRepository::new(pool);
+		repo.upsert("subject-a", &fixture("session-1")).await.expect("seed subject-a's session");
+
+		let removed = repo.delete("subject-b", "session-1").await.expect("query should not fail");
+		assert!(!removed, "a foreign subject's delete must report nothing removed");
+		assert!(
+			repo.get("subject-a", "session-1").await.expect("query should not fail").is_some(),
+			"the row must survive a foreign delete attempt"
+		);
+	}
+
+	#[tokio::test]
+	async fn delete_many_skips_foreign_ids_and_reports_only_the_owned_count() {
+		let pool = pool().await;
+		let repo = SessionRepository::new(pool);
+		repo.upsert("subject-a", &fixture("session-a")).await.expect("seed subject-a's session");
+		repo.upsert("subject-b", &fixture("session-b")).await.expect("seed subject-b's session");
+
+		let deleted = repo
+			.delete_many("subject-a", &["session-a".to_owned(), "session-b".to_owned()])
+			.await
+			.expect("query should not fail");
+
+		assert_eq!(deleted, 1, "only the id subject-a actually owns should count");
+		assert!(
+			repo.get("subject-b", "session-b").await.expect("query should not fail").is_some(),
+			"subject-b's session must survive"
+		);
+	}
+
+	#[tokio::test]
+	async fn upsert_refuses_to_move_an_existing_row_to_a_different_subject() {
+		let pool = pool().await;
+		let repo = SessionRepository::new(pool);
+		repo.upsert("subject-a", &fixture("session-1")).await.expect("seed subject-a's session");
+
+		let hijack_attempt = repo.upsert("subject-b", &fixture("session-1")).await;
+		assert!(
+			matches!(hijack_attempt, Err(SessionRepoError::SubjectMismatch { .. })),
+			"an upsert against an id owned by another subject must fail, not silently move it: got {hijack_attempt:?}"
+		);
+
+		assert!(
+			repo.get("subject-a", "session-1").await.expect("query should not fail").is_some(),
+			"the row must still belong to its original owner"
+		);
+		assert!(
+			repo.get("subject-b", "session-1").await.expect("query should not fail").is_none(),
+			"the failed attempt must not have moved the row"
+		);
+	}
+
+	#[tokio::test]
+	async fn set_status_many_updates_only_the_ids_this_subject_owns() {
+		let pool = pool().await;
+		let repo = SessionRepository::new(pool);
+		repo.upsert("subject-a", &fixture("session-a")).await.expect("seed subject-a's session");
+		repo.upsert("subject-b", &fixture("session-b")).await.expect("seed subject-b's session");
+
+		let updated = repo
+			.set_status_many(
+				"subject-a",
+				&["session-a".to_owned(), "session-b".to_owned()],
+				SessionStatus::Scheduled,
+				"2026-01-02T00:00:00Z",
+			)
+			.await
+			.expect("query should not fail");
+
+		assert_eq!(updated.len(), 1, "only the id subject-a actually owns should be reported as updated");
+		assert_eq!(updated[0].id, "session-a");
+
+		let foreign_after = repo
+			.get("subject-b", "session-b")
+			.await
+			.expect("query should not fail")
+			.expect("subject-b's session still exists");
+		assert!(
+			matches!(foreign_after.status, SessionStatus::Draft),
+			"a foreign id in the batch must not have its status changed"
+		);
 	}
 }

--- a/docs/study-nudge.md
+++ b/docs/study-nudge.md
@@ -381,13 +381,18 @@ client would let the two diverge silently:
 
 **`sessions` has an owner now.** #259 added `subject_id`, backfilled to
 `SINGLETON_SUBJECT` for every row that existed before the migration, and
-rebuilt `idx_sessions_status` as `(subject_id, status, updated_at DESC)` since
-that scan is about to be scoped per subject. Deliberately incomplete on its
-own: `SessionRepository`'s queries still neither read nor write the column, so
-a write through `upsert` fails on the new `NOT NULL` constraint until #260
-(SUB2) threads a real subject through every method. That is fine — #259 and
-#260 land back to back in the milestone's order (#295, P1.1 then P2.1), and
-neither is a deployable increment by itself.
+rebuilt `idx_sessions_status` as `(subject_id, status, updated_at DESC)` for
+the per-subject scan #260 (SUB2) then added: every non-admin method on
+`SessionRepository` (`list`, `get`, `upsert`, `delete`, `delete_many`,
+`set_status_many`, `touched_between`) now takes a `subject_id` and is scoped
+by it — `get` returns `None` for a foreign id rather than the row (an id is
+not a capability), `delete`/`delete_many` treat a foreign id as a no-op, and
+`upsert` refuses outright, as `SessionRepoError::SubjectMismatch`, to move an
+existing row to a different subject. The route layer does not extract a real
+subject yet — `handlers/db/session.rs` passes `SINGLETON_SUBJECT` explicitly,
+same as every other unauthenticated caller — that thread-through is #261
+(SUB3), whose own acceptance criterion (`grep -rn "SINGLETON_SUBJECT"` outside
+`subject.rs` finds nothing) is what retires those call sites.
 
 ### Trust model, stated plainly
 
@@ -466,20 +471,23 @@ arithmetic says.
 **There is no caller to paginate it.** `GET /sessions` could leave `list()`
 unpaginated because the client was the one caller, and the client already
 paginates the result in memory. `nudge::waker::consider` broke that: it calls
-`SessionRepository::list()` once per due subject to find a prepared session,
-and nothing sits above the waker to page through what comes back — the tick
-fires, the pass runs, and whatever `list()` hands back is read in full. A
-query on this path that assumes some caller will bound it is assuming a
-caller that does not exist.
+`SessionRepository::list(subject_id)` once per due subject to find a prepared
+session, and nothing sits above the waker to page through what comes back —
+the tick fires, the pass runs, and whatever `list()` hands back is read in
+full. A query on this path that assumes some caller will bound it is assuming
+a caller that does not exist.
 
 So the invariant is stated the other way round: **a read reachable from the
 waker declares its own bound**, in the query itself (a `LIMIT`, an indexed
 `WHERE`, or a narrower question than "everything") rather than in a caller
-that isn't there to enforce one. `list()` does not yet — `#262` (SLI1) is the
+that isn't there to enforce one. `list()` narrows *which subject's rows* it
+can see (#260/SUB2 — a query can no longer return another subject's sessions
+at all) but still does not bound *how many* — `#262` (SLI1) is the
 measurement of that gap, a characterisation test in `nudge::waker`'s test
-module pinning down today's `O(BATCH × |sessions|)` cost, and `#263` (SLI2)
-is where the query itself changes. `#262` deliberately does not fix the read;
-see its own out-of-scope note.
+module pinning down today's `O(BATCH × sessions this subject owns)` cost, and
+`#263` (SLI2) is where the query itself changes to a purpose-built,
+`LIMIT 1` lookup. `#262` deliberately does not fix the read; see its own
+out-of-scope note.
 
 ### One policy, one language
 
@@ -537,10 +545,12 @@ that retires a class needs a migration, and there is no mechanism that would
 notice if it forgot.
 
 **One subject.** `SubjectId` is a singleton until auth lands. Every table the
-study policy reads carries a `subject_id` column as of #259 — `sessions` was
-the last holdout — but `SessionRepository` itself does not filter or write it
-yet (#260); everything else already does. Nothing has been exercised with two
-subjects regardless.
+study policy reads carries a `subject_id` column as of #259, and every
+repository that reads or writes one — including `SessionRepository`, as of
+#260 — filters and writes it. What's still singleton is the *value*: nothing
+extracts a real `SubjectId` from a request yet, so every caller passes
+`SINGLETON_SUBJECT` explicitly (#261 replaces that at the route layer) and
+nothing has been exercised with two genuinely different subjects regardless.
 
 **The tag constant lives in three places.** `NUDGE_TAG` (`some-ui.study-nudge`)
 is hand-maintained in `file_host::nudge::payload`, in `public/sw.js`, and in


### PR DESCRIPTION
## Description

`nudge/waker.rs::consider` calls `SessionRepository::new(db.clone()).list()` once per due subject — before this PR, unscoped, so it could in principle return another subject's rows. `handlers/db/session.rs`'s eight route handlers had the same shape: every method on `SessionRepository` answered a question "about a person" without ever being told which person.

This PR closes that: every non-admin method on `SessionRepository` (`list`, `get`, `upsert`, `delete`, `delete_many`, `set_status_many`, `touched_between`) now takes a `subject_id: &str` and is scoped by it —

- `get(subject, id)` returns `None` for a well-formed id owned by another subject, the same as an id that does not exist — an id is not a capability.
- `delete`/`delete_many` treat a foreign id as a no-op, not a deletion; the row survives and the count/bool reflects only what was actually owned and removed.
- `set_status_many` with a mixed list of owned and foreign ids updates and reports only the owned ones.
- `upsert` refuses outright, as the new `SessionRepoError::SubjectMismatch`, to move an existing row to a different subject — enforced at the SQL layer via `ON CONFLICT ... WHERE sessions.subject_id = excluded.subject_id`, which SQLite reports as zero rows affected exactly when (and only when) a conflicting id belongs to someone else.

`nudge::waker::consider` now calls `list(subject_id)` instead of the unscoped `list()` — the one call site reachable from the waker. `handlers/db/session.rs`'s eight handlers pass `subject::SINGLETON_SUBJECT` explicitly at each call site: threading a real, request-extracted `SubjectId` through the route layer is #261 (SUB3), explicitly out of scope here per #260's own text; #261's own acceptance criterion (`grep -rn "SINGLETON_SUBJECT"` outside `subject.rs` finds nothing) is what retires these references.

**#262's characterisation test needed updating as part of this change**, not just left alone: it seeded 200 sessions under one shared `subject-local` id while asserting the waker read them once per due subject (`subject-0..39`). Once `list()` is scoped, none of those due subjects own any of that shared pool, so the old setup would have silently asserted a rows-read count of zero instead of measuring anything. The test now has each due subject seed and own `SESSIONS_PER_SUBJECT` (5) sessions of its own — through `SessionRepository::upsert` itself now that `upsert` writes `subject_id`, rather than the raw SQL the old test needed while `upsert` couldn't — keeping the same total row count (40 × 5 = 200) and the same `BATCH.min(DUE_SUBJECTS) × N` assertion shape, now correctly measuring "each subject's own read is unbounded within its scope" rather than a shared-table read that subject-scoping has already ruled out.

`docs/study-nudge.md` is updated in two places: the "`sessions` has an owner now" paragraph (which used to say `SessionRepository`'s queries "neither read nor write" `subject_id`) and the "One subject" known-unknown (which used to say the same). Both now describe the current, correct state: every repository method is scoped; only the *value* passed in remains the singleton until #261.

Fixes #260
Part of #295 (P2.1) — the first row of P2, unblocked now that #259 (P1.1) and #262 (P1.3) are both merged. #263 (SLI2, the actual read-bounding fix #262's characterisation test exists to guard) depends on both this PR and #262, and is next per #295.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) — repository methods gain a required parameter and new scoping behavior; existing single-subject callers are updated in the same PR so nothing breaks today.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- A new `crates/db/session::repository::tests` module (six tests, run against a fresh in-memory `SQLite` database via an embedded `sqlx::migrate!` — the same pattern #262 established in `nudge::waker`'s test module, reused here rather than reinvented): cross-subject `list`/`get` isolation, `delete`/`delete_many` refusing a foreign row, `upsert` refusing to move a row's owner, and `set_status_many` updating only the owned ids in a mixed batch.
- Sanity-checked the new tests actually gate real behavior: temporarily neutered `get`'s `WHERE subject_id = ?` clause (kept it syntactically valid so it still compiled) and confirmed `get_returns_none_for_a_well_formed_id_owned_by_a_different_subject` fails with a real assertion panic; reverted before committing.
- `apps/servers/file_host`'s existing `nudge::waker` tests, including #262's rewritten characterisation test, pass — `cargo test -p file_host nudge::`.
- `cargo check --workspace` and `cargo test --workspace --verbose` — full workspace green, no failures.
- `cargo clippy -p session_repo --no-deps --all-targets` and `cargo clippy -p file_host --no-deps --all-targets`, filtered to the four touched files: caught and fixed two real issues before they became debt — a missing-backticks doc-markdown nit on "SQLite", and a `format!` call in new code (`clippy.toml`'s `disallowed-macros` ban), fixed with `write!`/`push_str`. After fixing, the touched files' clippy output is byte-for-byte identical to the pre-change baseline (verified via `git stash`) except for the accepted `clippy::expect_used` pattern on test setup calls, matching #262/#299's precedent and `websocket.rs`'s existing test style. `lint.yml` doesn't gate PRs regardless.
- `cargo fmt --all -- --check` filtered to touched files, then `rustfmt --edition 2021` applied directly to the two files with real hits (`handlers/db/session.rs`, `crates/db/session/src/repository.rs` — both grew longer call signatures from the added `subject_id` parameter, past the wrap width). `waker.rs`'s one reported diff is confirmed pre-existing and untouched — verified against the unmodified baseline via `git stash`, same known nightly-vs-stable `rustfmt.toml` false positive noted in every prior PR in this relay.
- `cargo sqlx prepare --workspace` succeeds against every touched query.
- `python3 scripts/check_metric_contract.py` — unaffected (no new metric added), still passes.

**Test Configuration**:
* Toolchain: stable, `sqlx-cli` 0.7.4 (matches `test.yml`'s pin)
* SDK: workspace `migrations/` staged and applied to a scratch `DATABASE_URL` for compile-time `sqlx::query!` verification; the new `session_repo` test module embeds its own migrator against an isolated in-memory database, same as #262's `file_host` test.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (see clippy note above)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules — n/a

## Additional Notes

Continues the landing order in #295: follows #294 (P0.1/#296), #278 (P0.2/#297), #259 (P1.1/#298), #266 (P1.2/#299), #262 (P1.3/#300). This is the first row of P2 — once merged, #263 (P2.2/SLI2) and #261 (P2.3/SUB3) both become newly eligible, though #263 additionally needs #262 (already satisfied) and is the more natural next target since it's the fix this milestone's SLI1/SUB2 groundwork exists to enable.

---
_Generated by [Claude Code](https://claude.ai/code/session_016HiRNVqwWXQkK9vgV9cM3e)_